### PR TITLE
Update docs to show that target is optional for the swift publish plugin

### DIFF
--- a/publish.rst
+++ b/publish.rst
@@ -83,7 +83,7 @@ source
   Source file to publish
 
 target
-  Destiantion publish location
+  Destination publish location (only required when source is a single file)
 
 PyPI
 ----


### PR DESCRIPTION
Doc update to go along with https://github.com/drone/drone/pull/315
