### PR TITLE
fix the path in nginx websocket config example

### DIFF
--- a/install.rst
+++ b/install.rst
@@ -114,10 +114,11 @@ or greater. You also need to configure nginx to proxy websocket connections:
 .. code-block:: bash
 
     # Proxy for websockets
-    location = /feed {
+    location /api/stream {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header Host $http_host;
+        proxy_set_header Origin "";
 
         proxy_pass http://127.0.0.1:8080;
         proxy_redirect off;


### PR DESCRIPTION
As per https://github.com/drone/drone/blob/master/server/router/router.go#L33, the websocket path should be `/api/stream/user` and `/api/stream/stdout`.