### PR TITLE
fixed publish page format

### DIFF
--- a/publish.rst
+++ b/publish.rst
@@ -245,6 +245,7 @@ Result: Image pushed to `docker-registry.example.com/my-webapp:0.1` without logi
 Result: Image pushed to `docker-registry.example.com/my-webapp:$(git rev-parse --short HEAD)` using `myuser` account. 
 
 **Docker Hub, Push to Personal Account**
+
 .. code-block:: console
 
     publish:


### PR DESCRIPTION
One paragraph of the publish page is messed up:

![screen shot 2014-12-23 at 00 48 53](https://cloud.githubusercontent.com/assets/717363/5527027/846c611e-8a3d-11e4-81e8-6922733dfa40.png)
