### PR TITLE
renamed api client library to dronge-go and updated link

### DIFF
--- a/content/api/overview.md
+++ b/content/api/overview.md
@@ -26,4 +26,4 @@ interact with the API from client-side web applications.
 
 Here is a list of available API client libraries for working with the Drone API: 
 
-* [Go](https://github.com/drone/drone/tree/master/client) (official)
+* [drone-go (Go)](https://github.com/drone/drone-go/tree/master) (official)


### PR DESCRIPTION
Changed link to go client library because of repo restructuring.

I changed the name to drone-go (go) if another programming language might want to tune in

Does this look right?