### PR TITLE
Adding some additional links to plugin docs.

### DIFF
--- a/layouts/plugins/single.html
+++ b/layouts/plugins/single.html
@@ -9,17 +9,27 @@
 					</div>
 
 					<div class="grid-flex-cell grid-flex-cell-1of4">
-						<nav role='navigation' class="hidden">
+						<nav role='navigation'>
+							<h3>Plugin Links</h3>
+							{{ $currentNode := . }}
 							<ul class='list-unstyled side-nav'>
-								{{ $currentNode := . }}
-								{{ range .Site.Menus.usage }}
 								<li>
-									<a href="{{.URL}}" class="{{if ($currentNode.IsMenuCurrent "plugins" .) }} current-item{{end}}">{{ .Name }}</a>
+									<a href="http://discuss.drone.io/c/help">
+										Get Help
+									</a>
 								</li>
-								{{ end }}
+								<li>
+									<a href="https://github.com/{{.Params.user}}/{{.Params.repo}}/">
+										Source Code
+									</a>
+								</li>
+								<li>
+									<a href="https://hub.docker.com/r/plugins/{{.Params.repo}}/">
+										Docker Image
+									</a>
+								</li>
 							</ul>
 						</nav>
-
 						{{ template "partials/contribute.html" . }}
 					</div>
 			</article>


### PR DESCRIPTION
As per http://discuss.drone.io/t/additional-plugin-doc-links/23/1, this PR adds some additional links to plugin docs:

![image](https://cloud.githubusercontent.com/assets/75556/11949051/e501f58c-a82f-11e5-9f10-64c9fa3e20fa.png)

Since this is a bit of a departure from what we're currently doing, going to wait for @bradrydzewski 's input on whether he wants this or not.