### PR TITLE
Adding links to Discussion site in Community overview.

### DIFF
--- a/content/community/overview.md
+++ b/content/community/overview.md
@@ -13,12 +13,18 @@ To stay current with the latest releases and other announcement, see our
 [blog](http://blog.drone.io/). You can also find us at 
 [@droneio](https://twitter.com/droneio/) on Twitter.
 
+# Get Engaged
+
+We maintain a [Drone Discussion](http://discuss.drone.io/) site for the
+community to interact, get help, and plan future development.
+
 # Getting Help
 
-If you suspect that you have found a bug or are having trouble,
-file an issue on the Drone 
-[issue tracker](https://github.com/drone/drone/issues). You can also stop by
-our [Gitter room](https://gitter.im/drone/drone) and ask for help.
+If you suspect that you have found a bug, file an issue on the Drone 
+[issue tracker](https://github.com/drone/drone/issues). If you are having
+trouble getting started or figuring something out, stop by the 
+[Drone Discussion](http://discuss.drone.io/) site (in particular, the
+[Help!](http://discuss.drone.io/c/help) section).
 
 # Contributing to Drone
 
@@ -31,4 +37,6 @@ strengths and interests, we are always in need of help with:
 * [Demos](https://github.com/drone-demos)
 
 If you'd like help getting started or would like to talk to other users
-and contributors, stop by our [Gitter room](https://gitter.im/drone/drone).
+and contributors, stop by our [Gitter room](https://gitter.im/drone/drone)
+or introduce yourself in the [Development](http://discuss.drone.io/c/development)
+section of the [Drone Discussion](http://discuss.drone.io/) site.

--- a/layouts/community/single.html
+++ b/layouts/community/single.html
@@ -33,6 +33,11 @@
 									</a>
 								</li>
 								<li>
+									<a href="http://discuss.drone.io/">
+										Discussion Site
+									</a>
+								</li>
+								<li>
 									<a href="https://github.com/drone/drone/issues">
 										Issue Tracker
 									</a>


### PR DESCRIPTION
We're still shaking out the Discussion site, but I figured I'd go on ahead and get these links in place while I'm thinking about it.