### PR TITLE
Add links to existing remote setup text.

### DIFF
--- a/content/setup/overview.md
+++ b/content/setup/overview.md
@@ -24,7 +24,7 @@ REMOTE_DRIVER=github
 REMOTE_CONFIG=https://github.com?client_id=....&client_secret=....
 ```
 
-Please configure your [GitHub](../github) integration (or GitLab, Bitbucket, Gogs) before your proceed. Drone will not start until you have configured your version control integration.
+Please configure your [GitHub](../github) integration (or [GitLab](../gitlab), [Bitbucket](../bitbucket), [Gogs](../gogs)) before your proceed. Drone will not start until you have configured your version control integration.
 
 # Create and Run
 


### PR DESCRIPTION
Makes the GitLab, Bitbucket, and Gogs mentions under setup links (like GitHub was already).