### PR TITLE
Adding example of service containers with private images.

### DIFF
--- a/content/usage/services.md
+++ b/content/usage/services.md
@@ -45,7 +45,19 @@ image: library/postgres:9.2
 image: index.docker.io/library/postgres:9.2
 ```
 
-Use the pull attribute to instruct Drone to always pull the latest Docker image. This helps ensure you are always testing your code against the latest image:
+Provide your registry credentials if your service container image is private:
+
+```yaml
+---
+compose:
+  database:
+    image: myrepo/customdb:latest
+    auth_config:
+      username: octocat
+      password: password
+```
+
+Use the `pull` attribute to instruct Drone to always pull the latest Docker image. This helps ensure you are always testing your code against the latest image:
 
 ```yaml
 ---


### PR DESCRIPTION
This is very similar to the text in the Build section under the same "Images" section, but the usage case is important (and common) enough to where this needs to be abundantly clear.