### PR TITLE
fixed invalid command example

### DIFF
--- a/content/devs/cli.md
+++ b/content/devs/cli.md
@@ -106,7 +106,7 @@ drone build last octocat/hello-world
 Restart a previously executed build by build number:
 
 ```
-drone start octocat/hello-world 35
+drone build start octocat/hello-world 35
 ```
 
 # User Commands


### PR DESCRIPTION
I saw an invalid command example on CLI pages, here is the patch.