### PR TITLE
updating Yaml to YAML

### DIFF
--- a/content/devs/api/repos.md
+++ b/content/devs/api/repos.md
@@ -206,7 +206,7 @@ DELETE /api/repos/{owner}/{name}
 
 # Encrypt repo secrets
 
-Encryptes a Yaml file with secret environment variables for secure public storage.
+Encryptes a YAML file with secret environment variables for secure public storage.
 
 ```
 POST /api/repos/{owner}/{name}/encrypt

--- a/content/devs/plugins.md
+++ b/content/devs/plugins.md
@@ -22,7 +22,7 @@ notify:
 
 # Plugin Input
 
-Plugins receive a JSON payload as a command line argument that includes repository and build details. Plugin configuration parameters from the Yaml file are stored in the `vargs` section of the document.
+Plugins receive a JSON payload as a command line argument that includes repository and build details. Plugin configuration parameters from the YAML file are stored in the `vargs` section of the document.
 
 Example plugin input:
 

--- a/content/plugins/webhook.md
+++ b/content/plugins/webhook.md
@@ -46,7 +46,7 @@ For the use case we expose the following additional parameters:
 * `template` - Handlebars template to create a custom payload body. See [docs](http://handlebarsjs.com/)
 * `content_type` - HTTP request content type
 
-Example configuration that generate a custom Yaml payload:
+Example configuration that generate a custom YAML payload:
 
 ```yaml
 notify:

--- a/content/usage/secrets.md
+++ b/content/usage/secrets.md
@@ -13,7 +13,7 @@ toc = true
 
 Drone lets you store secret variables in an encrypted `.drone.sec` file in the root of your repository. This is useful when your build requires sensitive information that should not be stored in plaintext in your yaml file. This document assumes you have installed the Drone [command line tools](/devs/cli).
 
-Start with a plaintext Yaml file that defines your secrets. For demonstration purposes let's assume this file is stored on disk and named `secrets.yml`. Secrets are defined in the `environment` section of this file:
+Start with a plaintext YAML file that defines your secrets. For demonstration purposes let's assume this file is stored on disk and named `secrets.yml`. Secrets are defined in the `environment` section of this file:
 
 ```yaml
 ---
@@ -46,7 +46,7 @@ git commit -m "added .drone.sec file"
 
 # Interpolation
 
-Secrets are injected directly into the Yaml at runtime using the `$$` notation:
+Secrets are injected directly into the YAML at runtime using the `$$` notation:
 
 ```yaml
 ---
@@ -74,7 +74,7 @@ build:
 ```
 
 Secrets that are multiple lines or contain special characters should be escaped to
-avoid Yaml parsing errors post-interpolation. You can escape strings by wrapping
+avoid YAML parsing errors post-interpolation. You can escape strings by wrapping
 the variable in quotes as shown below:
 
 ```yaml
@@ -95,7 +95,7 @@ Drone automatically calculates and stores a checksum of your `.drone.yml` file i
 Invalid checksums result in the following error at the top of your build logs:
 
 ```
-Unable to validate Yaml checksum.
+Unable to validate YAML checksum.
 2ca66eb7be89f31afdebb197174abfa6dd14866ecbf9e552f44be5bd3244d08a
 ```
 
@@ -130,6 +130,6 @@ deploy:
 Secrets are not injected into your build if the checksum cannot be validated. This happens when you change your `.drone.yml` file without re-generating a `.drone.sec` file resulting in the following error message at the top of your build logs:
 
 ```
-Unable to validate Yaml checksum.
+Unable to validate YAML checksum.
 2ca66eb7be89f31afdebb197174abfa6dd14866ecbf9e552f44be5bd3244d08a
 ```

--- a/content/usage/variables.md
+++ b/content/usage/variables.md
@@ -38,7 +38,7 @@ Drone also injects `CI_` prefixed variables for compatibility with other systems
 
 # String Interpolation
 
-A subset of variables may be substituted directly into the Yaml at runtime using the `$$` notation:
+A subset of variables may be substituted directly into the YAML at runtime using the `$$` notation:
 
 * `$$BUILD_NUMBER` build number for the current build
 * `$$COMMIT` git sha for the current build, long format

--- a/content/usage/yaml.md
+++ b/content/usage/yaml.md
@@ -1,7 +1,7 @@
 +++
 date = "2015-12-05T16:00:21-08:00"
 draft = true
-title = "Yaml Spec"
+title = "YAML Spec"
 weight = 11
 menu = "usage"
 +++

--- a/contrib/plugin-gen.go
+++ b/contrib/plugin-gen.go
@@ -27,7 +27,7 @@ var (
 	repo  = flag.String("repo", "drone-slack", "github repository")
 )
 
-type Yaml struct {
+type YAML struct {
 	Plugin Plugin `yaml:"plugin"`
 }
 
@@ -64,7 +64,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	conf := Yaml{}
+	conf := YAML{}
 	err = yaml.Unmarshal(raw, &conf)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
More of a style preference, but since YAML is an acronym for "YAML Ain't Markup Language" and [Wikipedia](https://en.wikipedia.org/wiki/YAML) along with http://yaml.org/ use `YAML` I propose we refer to it either by uppercase or lowercase, not mixed case. 

This also follows the Google Code Review guide around how acronyms and initialisms should be handled https://github.com/golang/go/wiki/CodeReviewComments#initialisms.