### PR TITLE
Breaking up the feature chart. More inter-linking and ergonomic tweaks.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 public
+
+# IDE/Editor stuff
+.idea

--- a/content/setup/overview.md
+++ b/content/setup/overview.md
@@ -26,11 +26,11 @@ REMOTE_DRIVER=github
 REMOTE_CONFIG=https://github.com?client_id=....&client_secret=....
 ```
 
-For a full list of possible settings, see our [Settings Reference]({{< relref "settings.md" >}}). You may want to come back to this after completing your initial setup process.
+We'll be adding to this file as we progress through the setup process. 
 
 # Select and Configure a Remote Driver
 
-With your `dronerc` file created, refer to the [Remote Drivers]({{< relref "remotes.md" >}}) page for configuring Drone to work with your code hosting system of choice.
+With your `dronerc` file created, it's time to configure your [Remote Drivers] ({{< relref "remotes.md" >}}). We currently have support for [GitHub]({{< relref "github.md" >}}), [Bitbucket]({{< relref "bitbucket.md" >}}), [GitLab]({{< relref "gitlab.md" >}}), and [Gogs]({{< relref "gogs.md" >}}).
 
 # Select and Configure a Database
 

--- a/content/setup/remotes.md
+++ b/content/setup/remotes.md
@@ -4,7 +4,7 @@ draft = false
 title = "Remote Drivers"
 weight = 2
 menu = "installation"
-toc = true
+#toc = true
 +++
 
 Drone uses Remote Drivers to integrate and execute builds against your code hosting system of choice. Some things that the remote driver handles include:
@@ -12,23 +12,6 @@ Drone uses Remote Drivers to integrate and execute builds against your code host
 * Deploy key or credential management (to allow Drone to pull code)
 * Webhook configuration (so Drone knows when pushes happen)
 * Authenticating users against the remote driver (typically through oauth2)
-
-# Features support
-
-While the majority of user and developer scrutiny has been directed at our GitHub driver, the experience with our other supported services is solid. Here is where each of the remote drivers currently stands:
-
-| Feature/Remote            | GitHub  | GitLab  | BitBucket Cloud     | Gogs    |
-|---------------------------|---------|---------|---------------------|---------|
-| Supported version         | --/--   | 8.2+    | --/--               | --/--   |
-| VCS                       | **git** | **git** | **git ( only )**    | **git** |
-| Auth method               | ouath2  | oauth2  | oauth2              | manual  |
-| Push events               | **yes** | **yes** | **yes**             | **yes** |
-| Push tags events          | **yes** | **yes** | **yes**             | no      |
-| Merge requests            | **yes** | **yes** | **partially**       | no      |
-| Commit statuses           | **yes** | **yes** | **yes**             | no      |
-| Restrict by organizations | **yes** | no      | **yes**             | no      |
-
-*partially* - Drone can fetch merge requests direct from source repository, from BitBucket, but if user who activates drone on target repo has no access to source repo, git clone fails
 
 # Configuring a Remote Driver
 
@@ -39,4 +22,7 @@ Depending on which service or system you are hosting your code on, you'll want t
 * [GitLab]({{< relref "gitlab.md" >}})
 * [Gogs]({{< relref "gogs.md" >}})
 
-Once you have configured your remote, it's time to [Select and Configure a Database]({{< relref "setup/overview.md#select-and-configure-a-database" >}}).
+# Next Steps
+
+Once you have configured your Remote Driver, it's time to [Select and 
+Configure a Database]({{< relref "setup/overview.md#select-and-configure-a-database" >}}).

--- a/content/setup/remotes/bitbucket.md
+++ b/content/setup/remotes/bitbucket.md
@@ -4,6 +4,7 @@ draft = false
 title = "Bitbucket Cloud"
 weight = 1
 menu = "remotes"
+toc = true
 +++
 
 Drone comes with built-in support for Bitbucket Cloud. Bitbucket Server is not yet supported. To enable Bitbucket Cloud you should configure the Bitbucket driver using the following environment variables:
@@ -48,9 +49,27 @@ Please use `http://drone.mycompany.com/authorize` as the Authorization callback 
 * Repositories:Read
 * Webhooks:Read and Write
 
-# Known Issues
+# Remote Driver Feature Chart
 
-This section details known issues and planned features:
+Drone currently only supports BitBucket Cloud (hosted BitBucket). 
+Contributions for BitBucket Server are welcomed.
+ 
+Also, we only support git on BitBucket Cloud. While we do have a Mercurial 
+Drone Plugin, the webhook output is slightly different for Hg projects. We'd 
+love to see pull requests for this as well.
 
-* Pull Request support
-* Mercurial support
+| Feature/Remote            | BitBucket Cloud      |
+|---------------------------|----------------------|
+| Supported version         | BitBucket Cloud Only |
+| VCS                       | **git ( only )**     |
+| Auth method               | oauth2               |
+| Push events               | yes                  |
+| Push tags events          | yes                  |
+| Merge requests            | **partially**        |
+| Commit statuses           | yes                  |
+| Restrict by organizations | yes                  |
+
+# Next Steps
+
+Once you have configured your Remote Driver, it's time to [Select and 
+Configure a Database]({{< relref "setup/overview.md#select-and-configure-a-database" >}}).

--- a/content/setup/remotes/github.md
+++ b/content/setup/remotes/github.md
@@ -4,6 +4,7 @@ draft = false
 title = "GitHub"
 weight = 2
 menu = "remotes"
+toc = true
 +++
 
 Drone comes with built-in support for GitHub and GitHub Enterprise. To enable GitHub you should configure the GitHub driver using the following environment variables:
@@ -44,3 +45,25 @@ This section lists all connection options used in the connection string format. 
 You must register your application with GitHub in order to generate a Client and Secret. Navigate to your account settings and choose Applications from the menu, and click Register new application.
 
 Please use `http://drone.mycompany.com/authorize` as the Authorization callback URL.
+
+# Remote Driver Feature Chart
+
+Since the majority of our users (including Drone itself) use GitHub, the 
+GitHub remote is in great shape. At any given time, Drone should work well 
+with both GitHub and GitHub Enterprise.
+
+| Feature/Remote            | GitHub                       |
+|---------------------------|------------------------------|
+| Supported versions        | GitHub and GitHub Enterprise |
+| VCS                       | git                          |
+| Auth method               | ouath2                       |
+| Push events               | yes                          |
+| Push tags events          | yes                          |
+| Merge requests            | yes                          |
+| Commit statuses           | yes                          |
+| Restrict by organizations | yes                          |
+
+# Next Steps
+
+Once you have configured your Remote Driver, it's time to [Select and 
+Configure a Database]({{< relref "setup/overview.md#select-and-configure-a-database" >}}).

--- a/content/setup/remotes/gitlab.md
+++ b/content/setup/remotes/gitlab.md
@@ -4,6 +4,7 @@ draft = false
 title = "GitLab"
 weight = 3
 menu = "remotes"
+toc = true
 +++
 
 > GitLab support is experimental and unstable due to high variation in GitLab configurations and versions. We highly recommend using [Gogs](https://github.com/gogits/gogs) as an alternative to GitLab.
@@ -46,3 +47,24 @@ This section lists all connection options used in the connection string format. 
 You must register your application with GitLab in order to generate a Client and Secret. Navigate to your account settings and choose Applications from the menu, and click New Application.
 
 Please use `http://drone.mycompany.com/authorize` as the Authorization callback URL.
+
+# Remote Driver Feature Chart
+
+Drone is relatively well-supported on GitLab, though compatibility is is 
+sometimes broken due to changes in GitLab from version to version.
+
+| Feature/Remote            | GitLab  |
+|---------------------------|---------|
+| Supported version         | 8.2+    |
+| VCS                       | git     |
+| Auth method               | oauth2  |
+| Push events               | yes     |
+| Push tags events          | yes     |
+| Merge requests            | yes     |
+| Commit statuses           | yes     |
+| Restrict by organizations | **no**  |
+
+# Next Steps
+
+Once you have configured your Remote Driver, it's time to [Select and 
+Configure a Database]({{< relref "setup/overview.md#select-and-configure-a-database" >}}).

--- a/content/setup/remotes/gogs.md
+++ b/content/setup/remotes/gogs.md
@@ -4,6 +4,7 @@ draft = false
 title = "Gogs"
 weight = 4
 menu = "remotes"
+toc = true
 +++
 
 Drone comes with built-in support for Gogs version `0.6.16.1022` and higher. Please ensure you are running the latest version of Gogs to avoid compatibility issues. To enable Gogs you should configure the Gogs driver using the following environment variables:
@@ -34,3 +35,24 @@ This section lists all connection options used in the connection string format. 
 
 * `open=false` allows users to self-register. Defaults to false for security reasons.
 * `skip_verify=false` skip ca verification if self-signed certificate. Defaults to false for security reasons.
+
+# Remote Driver Feature Chart
+
+While Gogs and Drone's support for Gogs are still developing, this is an 
+excellent option for teams with very simple hosting needs. 
+
+| Feature/Remote            | Gogs         |
+|---------------------------|--------------|
+| Supported version         | 0.6.16.1022+ |
+| VCS                       | git          |
+| Auth method               | manual       |
+| Push events               | yes          |
+| Push tags events          | **no**       |
+| Merge requests            | **no**       |
+| Commit statuses           | **no**       |
+| Restrict by organizations | **no**       |
+
+# Next Steps
+
+Once you have configured your Remote Driver, it's time to [Select and 
+Configure a Database]({{< relref "setup/overview.md#select-and-configure-a-database" >}}).


### PR DESCRIPTION
This doesn't address all of the concerns about Remote Driver setup docs, but I did as much as I was sure of. The larger feature chart was broken up between the various remotes, since we are assuming that most people have already chosen their code hosting system/service before getting to us.

I've also continued to add more direction as far as next steps, so each remote driver nudges you along towards configuring your database next.