### PR TITLE
Swap out deprecated goauth2 for golang.org/x/oauth2.

### DIFF
--- a/contrib/plugin-gen-all.go
+++ b/contrib/plugin-gen-all.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"os/exec"
 
-	"code.google.com/p/goauth2/oauth"
+	"golang.org/x/oauth2"
 	"github.com/google/go-github/github"
 )
 
@@ -22,10 +22,9 @@ var (
 func main() {
 	flag.Parse()
 
-	t := &oauth.Transport{
-		Token: &oauth.Token{AccessToken: *token},
-	}
-	client := github.NewClient(t.Client())
+	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: *token})
+	httpClient := oauth2.NewClient(oauth2.NoContext, tokenSource)
+	client := github.NewClient(httpClient)
 
 	opts := &github.RepositoryListByOrgOptions{}
 	opts.PerPage = 100

--- a/contrib/plugin-gen.go
+++ b/contrib/plugin-gen.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"code.google.com/p/goauth2/oauth"
+	"golang.org/x/oauth2"
 	"github.com/BurntSushi/toml"
 	"github.com/google/go-github/github"
 	"gopkg.in/yaml.v2"
@@ -49,10 +49,9 @@ type Plugin struct {
 func main() {
 	flag.Parse()
 
-	t := &oauth.Transport{
-		Token: &oauth.Token{AccessToken: *token},
-	}
-	client := github.NewClient(t.Client())
+	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: *token})
+	httpClient := oauth2.NewClient(oauth2.NoContext, tokenSource)
+	client := github.NewClient(httpClient)
 
 	dst := fmt.Sprintf("static/logos/%s.svg", strings.Replace(*repo, "drone-", "", -1))
 	err := download(client, "logo.svg", dst)


### PR DESCRIPTION
When I was attempting to run the plugin-gen and plugin-gen-all commands, I was running into some go get issues with `code.google.com/p/goauth2/oauth`, which is now deprecated. I took a few minutes to adapt these two to use the current `golang.org/x/oauth2`. 

Everything works locally, but I don't profess to be an expert with oauth2 or the Go GitHub API. This could use some more eyes.