### PR TITLE
Update docs to reflect behaviour of drone secure command

### DIFF
--- a/content/devs/cli.md
+++ b/content/devs/cli.md
@@ -185,13 +185,13 @@ OPTIONS:
 
 To generate a `.drone.sec` file for a repository:
 
-```Bash
+```bash
 drone secure --repo octocat/hello-world
 ```
 
 To use a file other than the default `.drone.sec.yml` use the `--in` option:
 
-```Bash
+```bash
 drone secure --repo octocat/hello-world --in filename.yml
 ```
 

--- a/content/devs/cli.md
+++ b/content/devs/cli.md
@@ -164,7 +164,7 @@ TODO
 
 Drone lets you store secret variables in an encrypted `.drone.sec` file in the root of your repository. This is useful when your build requires sensitive information that should not be stored in plaintext in your YAML file.
 
-The `drone secure` command takes the plaintext YAML file containing your secret variables and generates the encrypted `.drone.sec` file. Details of the format of the plaintext YAML file and example usage can be found in the [secrets usage documentation](/usage/secrets).
+The `drone secure` command takes the plaintext YAML file containing your secret variables and generates the encrypted `.drone.sec` file. Details of the format of the plaintext YAML file and example usage can be found in the [secrets usage documentation]({{< ref "usage/secrets.md" >}}).
 
 Run `drone help secure` for usage information:
 

--- a/content/devs/cli.md
+++ b/content/devs/cli.md
@@ -18,10 +18,19 @@ sudo install -t /usr/local/bin drone
 
 __OSX__ binary installation instructions:
 
-```bash
-curl http://downloads.drone.io/drone-cli/drone_darwin_amd64.tar.gz | tar zx
-sudo cp drone /usr/local/bin
-```
+* Download and install using [Homebrew](http://brew.sh/):
+
+    ```bash
+    brew tap drone/drone
+    brew install drone
+    ```
+
+* Or manually download and install the binary:
+
+    ```bash
+    curl http://downloads.drone.io/drone-cli/drone_darwin_amd64.tar.gz | tar zx
+    sudo cp drone /usr/local/bin
+    ```
 
 # Setup
 
@@ -153,7 +162,38 @@ TODO
 
 # Secret Management
 
-TODO
+Drone lets you store secret variables in an encrypted `.drone.sec` file in the root of your repository. This is useful when your build requires sensitive information that should not be stored in plaintext in your YAML file.
+
+The `drone secure` command takes the plaintext YAML file containing your secret variables and generates the encrypted `.drone.sec` file. Details of the format of the plaintext YAML file and example usage can be found in the [secrets usage documentation](/usage/secrets).
+
+Run `drone help secure` for usage information:
+
+```
+NAME:
+   drone secure - creates a secure yaml file
+
+USAGE:
+   drone secure [command options] [arguments...]
+
+OPTIONS:
+   --in ".drone.sec.yml"	input path to the plaintext secret file (use - for stdin)
+   --out ".drone.sec"		output path for the encrypted secret file (use - for stdout)
+   --repo 			name of the repository
+   --yaml ".drone.yml"		path to .drone.yml file
+   --checksum			calculate and encrypt the yaml checksum
+```
+
+To generate a `.drone.sec` file for a repository:
+
+```Bash
+drone secure --repo octocat/hello-world
+```
+
+To use a file other than the default `.drone.sec.yml` use the `--in` option:
+
+```Bash
+drone secure --repo octocat/hello-world --in filename.yml
+```
 
 # Local Testing
 

--- a/content/usage/secrets.md
+++ b/content/usage/secrets.md
@@ -14,7 +14,7 @@ toc = true
 
 Drone lets you store secret variables in an encrypted `.drone.sec` file in the root of your repository. This is useful when your build requires sensitive information that should not be stored in plaintext in your yaml file. This document assumes you have installed the Drone [command line tools](/devs/cli).
 
-Start with a plaintext YAML file that defines your secrets. For demonstration purposes let's assume this file is stored on disk and named `secrets.yml`. Secrets are defined in the `environment` section of this file:
+Start with a plaintext YAML file that defines your secrets. By default, the command line tool expects a file named `.drone.sec.yml`, so we'll use that here. Secrets are defined in the `environment` section of this file:
 
 ```yaml
 ---
@@ -35,7 +35,7 @@ deploy:
 Encrypt the `secrets.yml` file and generate a `.drone.sec` file:
 
 ```
-drone secure --repo octocat/hello-world --in secrets.yml
+drone secure --repo octocat/hello-world
 ```
 
 Commit the encrypted `.drone.sec` file to the root of your repository:


### PR DESCRIPTION
* Added brew to list of OSX install options
* Documentation of `drone secure` command
* Use default filename `.drone.sec.yml` in example of generating `.drone.sec` file in usage