### PR TITLE
Add a note to omit trailing slash from URL specified in DRONE_SERVER

### DIFF
--- a/content/devs/cli.md
+++ b/content/devs/cli.md
@@ -28,7 +28,7 @@ sudo cp drone /usr/local/bin
 You will need to provide the Drone command line tools with the location of your Drone installation as well as an access token for authentication. You can retrieve a Drone personal access token from your user profile screen.
 
 ```bash
-export DRONE_SERVER=http://myserver.com
+export DRONE_SERVER=<http://>
 export DRONE_TOKEN=<token>
 ```
 

--- a/content/devs/cli.md
+++ b/content/devs/cli.md
@@ -28,9 +28,11 @@ sudo cp drone /usr/local/bin
 You will need to provide the Drone command line tools with the location of your Drone installation as well as an access token for authentication. You can retrieve a Drone personal access token from your user profile screen.
 
 ```bash
-export DRONE_SERVER=<http://>
+export DRONE_SERVER=http://myserver.com
 export DRONE_TOKEN=<token>
 ```
+
+*Note that the Drone server URL must __not__ contain a trailing slash.*
 
 # Repo Commands
 


### PR DESCRIPTION
From [this discussion](https://discuss.drone.io/t/attempting-to-secure-data-results-in-404/138) I discovered trailing slashes must not be present in the URL specified in DRONE_SERVER. Have updated the CLI docs to make a note of this.