### PR TITLE
Create a user by POSTing to /api/users

### DIFF
--- a/content/devs/api/users.md
+++ b/content/devs/api/users.md
@@ -80,7 +80,7 @@ Example Response Body:
 Creates a new user account with the specified external login.
 
 ```
-POST /api/users/{login}
+POST /api/users
 ```
 
 


### PR DESCRIPTION
The API path for creating a user is wrong.

See: https://github.com/drone/drone/blob/master/router/router.go#L80