### PR TITLE
Clarify notify with `change` condition.

### DIFF
--- a/content/usage/notify.md
+++ b/content/usage/notify.md
@@ -43,6 +43,8 @@ notify:
       change: true
 ```
 
+While `success` and `failure` will trigger a notification when a build finishes with that outcome, `change` will notify regardless of outcome.
+
 Execute a notification step if the branch is `master`:
 
 ```yaml


### PR DESCRIPTION
Naively assumed that `change: true` meant that notifications only appear when the status changes (e.g. a branch goes from passing to failing), but based on the notifications we've been getting, it looks like it sends notifications any time the branch changes (e.g. a new build passes or fails).