### PR TITLE
docs: update nginx settings

### DIFF
--- a/content/setup/proxy_reverse.md
+++ b/content/setup/proxy_reverse.md
@@ -42,6 +42,9 @@ location / {
     proxy_redirect off;
     proxy_http_version 1.1;
     proxy_buffering off;
+    proxy_request_buffering off;
+    # build agents will timeout after whatever value is set for the proxy_read_timeout
+    proxy_read_timeout 12h;
 
     chunked_transfer_encoding off;
 }


### PR DESCRIPTION
Made two changes here:

1. `proxy_request_buffering off` - this setting allows the logs to be streaming asynchronously to the server. Without this, the logs were not being persisted to the db or shown in the UI; instead they were caught in the nginx buffer instead of being forwarded immediately to the drone server.
1. `proxy_read_timeout 12h` added a comment in the config to explain. Users can set this value to their discretion.