### PR TITLE
compose -> services, add --image to secret example

### DIFF
--- a/content/usage/services.md
+++ b/content/usage/services.md
@@ -52,9 +52,9 @@ services:
 Drone supports private images that require password authentication. You can use the command line utility to register authentication credentials:
 
 ```
-drone secrets add octocat/hello-world REGISTRY_USERNAME octocat
-drone secrets add octocat/hello-world REGISTRY_PASSWORD pa55word
-drone secrets add octocat/hello-world REGISTRY_EMAIL octocat@github.com
+drone secrets add --image=UNCERTAIN? octocat/hello-world REGISTRY_USERNAME octocat
+drone secrets add --image=UNCERTAIN? octocat/hello-world REGISTRY_PASSWORD pa55word
+drone secrets add --image=UNCERTAIN? octocat/hello-world REGISTRY_EMAIL octocat@github.com
 ```
 
 You can alternatively specify the authentication credentials directly in the Yaml:
@@ -62,7 +62,7 @@ You can alternatively specify the authentication credentials directly in the Yam
 ```yaml
 services:
   database:
-    image: postgres
+    image: registry.yourcompany.com/your/image:tag
     auth_config:
       username: octocat
       password: pa55word
@@ -111,7 +111,7 @@ For security reasons this option is only available to trusted repositories. Trus
 Use the privileged attribute to run your service in a privileged Docker container:
 
 ```yaml
-compose:
+services:
   dind:
     image: docker:dind
     privileged: true

--- a/content/usage/services.md
+++ b/content/usage/services.md
@@ -52,9 +52,9 @@ services:
 Drone supports private images that require password authentication. You can use the command line utility to register authentication credentials:
 
 ```
-drone secrets add --image=UNCERTAIN? octocat/hello-world REGISTRY_USERNAME octocat
-drone secrets add --image=UNCERTAIN? octocat/hello-world REGISTRY_PASSWORD pa55word
-drone secrets add --image=UNCERTAIN? octocat/hello-world REGISTRY_EMAIL octocat@github.com
+drone secrets add octocat/hello-world REGISTRY_USERNAME octocat
+drone secrets add octocat/hello-world REGISTRY_PASSWORD pa55word
+drone secrets add octocat/hello-world REGISTRY_EMAIL octocat@github.com
 ```
 
 You can alternatively specify the authentication credentials directly in the Yaml:


### PR DESCRIPTION
This pull request does a couple of things:

- It adds the --image flag to the example for adding secrets (this is unfinished, as I am not sure what the image should be)
- When explaining the auth config, the specified image (postgres) is a public one, I changed it to an example of using an image from a private repository (registry.yourcompany.com/your/image:tag) 
- There was a typo / bad copy paste job in the last example, I changed `compose:` to `services:`