### PR TITLE
Fix type in PLUGIN_FILTER section (setup/settings.md)

### DIFF
--- a/content/setup/settings.md
+++ b/content/setup/settings.md
@@ -44,7 +44,7 @@ Default: `plugins/*`
 This setting contains a space-separated list of patterns for determining which plugins can be pulled and ran. By disallowing open season on plugins, we prevent some classes of malicious plugins sneaking into builds.
 
 To use an example, let's say you've created an organization on Docker
-Hub called `myorg`. Here's a REMOTE_DRIVER setting value that would allow the standard Drone plugins plus your org:
+Hub called `myorg`. Here's a PLUGIN_FILTER setting value that would allow the standard Drone plugins plus your org:
 
 ```
 PLUGIN_FILTER=plugins/* myorg/*
@@ -58,7 +58,7 @@ PLUGIN_FILTER=plugins/* quay.io/myorg/*
 
 ## PLUGIN_PARAMS
 
-This setting may be used to define some global parameters to pass into all plugins on all repositories. 
+This setting may be used to define some global parameters to pass into all plugins on all repositories.
 
 > Be careful what you put in here, since it will be trivial for a malicious developer to obtain the values found in this setting.
 


### PR DESCRIPTION
- In [#PLUGIN_FILTER](https://github.com/drone/docs/blob/master/content/setup/settings.md#plugin_filter) the phrase was mentionning a REMOTE_DRIVER value where a PLUGIN_FILTER value was shown behind it.
- Sneaky empty space removed by my text editor