### PR TITLE
Fix apache reverse proxy for logs/ endpoint

### DIFF
--- a/content/installation/network/proxy_reverse.md
+++ b/content/installation/network/proxy_reverse.md
@@ -71,8 +71,10 @@ Example [apache](http://httpd.apache.org) reverse proxy configuration:
   ProxyPass /ws/ ws://localhost:8000/ws/
   ProxyPassReverse /ws/ ws://localhost:8000/ws/
 
-  ProxyPass /api/queue/logs ws://127.0.0.1:8000/api/queue/logs
-  ProxyPassReverse /api/queue/logs ws://127.0.0.1:8000/api/queue/logs
+  RewriteEngine On
+  RewriteCond %{REQUEST_METHOD} =GET
+  RewriteRule ^/api/queue/logs/(.*) ws://localhost:8000/api/queue/logs/$1 [P]
+  ProxyPassReverse /api/queue/logs ws://localhost:8000/api/queue/logs
 
   ProxyPass /api/queue/pull ws://127.0.0.1:8000/api/queue/pull
   ProxyPassReverse /api/queue/pull ws://127.0.0.1:8000/api/queue/pull


### PR DESCRIPTION
Only GET method should be upgraded to websockets, not POST