### PR TITLE
Remove quotes around mysql in DATABASE_DRIVER

### DIFF
--- a/content/setup/database.md
+++ b/content/setup/database.md
@@ -34,7 +34,7 @@ See the official postgres connection string [documentation](http://www.postgresq
 Configure a Mysql database backend:
 
 ```
-DATABASE_DRIVER="mysql"
+DATABASE_DRIVER=mysql
 DATABASE_CONFIG="root:pa55word@tcp(localhost:3306)/drone?parseTime=true"
 ```
 See the driver [documentation](https://github.com/go-sql-driver/mysql#dsn-data-source-name) for a complete set of configuration options and examples.

--- a/content/setup/database.md
+++ b/content/setup/database.md
@@ -35,7 +35,7 @@ Configure a Mysql database backend:
 
 ```
 DATABASE_DRIVER=mysql
-DATABASE_CONFIG="root:pa55word@tcp(localhost:3306)/drone?parseTime=true"
+DATABASE_CONFIG=root:pa55word@tcp(localhost:3306)/drone?parseTime=true
 ```
 See the driver [documentation](https://github.com/go-sql-driver/mysql#dsn-data-source-name) for a complete set of configuration options and examples.
 


### PR DESCRIPTION
The quotes are not needed, and cause drone startup to fail with this error:

```
time="2016-10-20T18:09:04Z" level=error msg="sql: unknown driver \"\\\"mysql\\\"\" (forgotten import?)"
```

I found this mentioned on the [Gitterforum pages](http://www.gitterforum.com/discussion/drone-drone?page=1713); search for "forgotten import" on that page.