### PR TITLE
Fix WebSocket proxy headers to Nginx reverse proxy example

### DIFF
--- a/content/setup/proxy_reverse.md
+++ b/content/setup/proxy_reverse.md
@@ -36,7 +36,6 @@ location / {
     proxy_set_header X-Forwarded-For $remote_addr;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Host $http_host;
-    proxy_set_header Origin "";
 
     proxy_pass http://127.0.0.1:8000;
     proxy_redirect off;

--- a/content/setup/proxy_reverse.md
+++ b/content/setup/proxy_reverse.md
@@ -43,6 +43,10 @@ location / {
     proxy_http_version 1.1;
     proxy_buffering off;
 
+    # Connection upgrade for WebSockets
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade;
+
     chunked_transfer_encoding off;
 }
 ```

--- a/content/setup/proxy_reverse.md
+++ b/content/setup/proxy_reverse.md
@@ -46,6 +46,11 @@ location / {
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
 
+    # WebSockets are affected by proxy_read_timeout (default 60s)
+    # Current websocket implementation does not perform heartbeat/ping
+    # within these 60s, causing connection to close.
+    proxy_read_timeout 3600s;
+
     chunked_transfer_encoding off;
 }
 ```

--- a/content/setup/proxy_reverse.md
+++ b/content/setup/proxy_reverse.md
@@ -45,7 +45,7 @@ location / {
 
     # Connection upgrade for WebSockets
     proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade;
+    proxy_set_header Connection "upgrade";
 
     chunked_transfer_encoding off;
 }


### PR DESCRIPTION
This PR adds necessary reverse proxy headers to Nginx preventing `Error during WebSocket handshake: Unexpected response code: 400`

It also removes the `Origin` header, which was causing WebSocket connections to fail with the client in agent mode.

Finally it increases the `proxy_read_timeout` to 1hr, since the WS connection does not perform any ping or heartbeat within that 60s, causing connection to drop.

The latter should be adressed in the WS implementation, removing the need for increasing the read timeout.

All these changes have been tested on latest Nginx stable, and Drone 0.5 master + Drone CLI 0.5