### PR TITLE
Ensure strings that look like exponent notation are parsed as strings

### DIFF
--- a/content/usage/config/substitution.md
+++ b/content/usage/config/substitution.md
@@ -17,7 +17,7 @@ Example commit substitution:
 pipeline:
   docker:
     image: plugins/docker
-+   tags: ${DRONE_COMMIT_SHA}
++   tags: "${DRONE_COMMIT_SHA}"
 ```
 
 Example tag substitution:
@@ -26,7 +26,7 @@ Example tag substitution:
 pipeline:
   docker:
     image: plugins/docker
-+   tags: ${DRONE_TAG}
++   tags: "${DRONE_TAG}"
 ```
 
 # String Operations
@@ -48,7 +48,7 @@ Example variable substitution strips `v` prefix from `v.1.0.0`:
 pipeline:
   docker:
     image: plugins/docker
-+   tags: ${DRONE_TAG##v}
++   tags: "${DRONE_TAG##v}"
 ```
 
 List of emulated string operations:

--- a/content/usage/config/substitution.md
+++ b/content/usage/config/substitution.md
@@ -39,7 +39,7 @@ Example variable substitution with substring:
 pipeline:
   docker:
     image: plugins/docker
-+   tags: ${DRONE_COMMIT_SHA:0:8}
++   tags: "${DRONE_COMMIT_SHA:0:8}"
 ```
 
 Example variable substitution strips `v` prefix from `v.1.0.0`:


### PR DESCRIPTION
Ensure strings that look like exponent notation are parsed as strings. 

For example, a commit hash with first 8 characters "680841e1" would be parsed into "6.80841e+06". This is not expected behaviour and causes docker tags to be invalid:

<img width="1107" alt="screen shot 2017-08-19 at 3 14 21 pm" src="https://user-images.githubusercontent.com/1705906/29484478-1d84614c-84f2-11e7-926e-3a0bf8a9f027.png">
