### PR TITLE
Highlight registry credentials are pull-only

### DIFF
--- a/content/usage/secrets/registries.md
+++ b/content/usage/secrets/registries.md
@@ -9,7 +9,11 @@ menu:
     parent: usage_secrets
 ---
 
-Drone provides the ability to store registry credentials. These credentials can be used to download private pipeline images defined in your Yaml configuration file.
+Drone provides the ability to store registry credentials. These credentials can be used to pull private pipeline images defined in your Yaml configuration file.
+
+{{% alert info %}}
+These credentials are never exposed to your pipeline, which means they cannot be used to push, and are safe to use with pull requests, for example.
+{{% /alert %}}
 
 Example configuration using a private image:
 

--- a/content/usage/secrets/registries.md
+++ b/content/usage/secrets/registries.md
@@ -12,7 +12,7 @@ menu:
 Drone provides the ability to store registry credentials. These credentials can be used to pull private pipeline images defined in your Yaml configuration file.
 
 {{% alert info %}}
-These credentials are never exposed to your pipeline, which means they cannot be used to push, and are safe to use with pull requests, for example.
+These credentials are never exposed to your pipeline, which means they cannot be used to push, and are safe to use with pull requests, for example. Pushing to a registry still require setting credentials for the appropriate plugin.
 {{% /alert %}}
 
 Example configuration using a private image:


### PR DESCRIPTION
Remind people that if they are set, these cannot be used to push. Pushing still requires explicit credentials.