### PR TITLE
Update gitea.md

### DIFF
--- a/content/install/integrations/gitea.md
+++ b/content/install/integrations/gitea.md
@@ -18,6 +18,11 @@ version: '2'
 services:
   drone-server:
     image: drone/drone:{{% version %}}
+    ports:
+      - 80:8000
+    volumes:
+      - /var/lib/drone:/var/lib/drone/
+    restart: always
     environment:
       - DRONE_OPEN=true
       - DRONE_HOST=${DRONE_HOST}


### PR DESCRIPTION
To reflect discussion https://discourse.drone.io/t/basic-drone-install-with-docker/804/2

Closes #263 

```
  drone-server:
    ...
    ports:
      - 80:8000
    volumes:
      - /var/lib/drone:/var/lib/drone/
    restart: always
```

is also missing in other integrations (Github, Gitlab, Gogs, Bitbucket Cloud, Bitbucket Server, Coding)