### PR TITLE
Adding Server Setup section in spanish

### DIFF
--- a/content/install/server/apache.es.md
+++ b/content/install/server/apache.es.md
@@ -23,7 +23,7 @@ ProxyPass / http://127.0.0.1:8000/
 ProxyPassReverse / http://127.0.0.1:8000/
 ```
 
-Debes tener los siguientes módules de Apache instalados:
+Debes tener los siguientes módulos de Apache instalados:
 
 ```nohighlight
 a2enmod proxy

--- a/content/install/server/apache.es.md
+++ b/content/install/server/apache.es.md
@@ -1,0 +1,60 @@
++++
+date = "2017-04-15T14:39:04+02:00"
+title = "Configuración con Apache"
+url = "setup-with-apache"
+
+[menu.install]
+  identifier = "setup-with-apache"
+  parent = "install_server"
+  weight = 5
++++
+
+Ésta guía provee una vista corta para instalar un servidor de Drone detrás de un servidor Apache2. Ésta es una configuración de ejemplo:
+
+```nohighlight
+ProxyPreserveHost On
+
+RequestHeader set X-Forwarded-Proto "https"
+
+ProxyPass /ws/ ws://localhost:8000/ws/
+ProxyPassReverse /ws/ ws://localhost:8000/ws/
+
+ProxyPass / http://127.0.0.1:8000/
+ProxyPassReverse / http://127.0.0.1:8000/
+```
+
+Debes tener los siguientes módules de Apache instalados:
+
+```nohighlight
+a2enmod proxy
+a2enmod proxy_http
+a2enmod proxy_wstunnel
+```
+
+Debes configurar Apache con `X-Forwarded-Proto` cuando se use https.
+
+```diff
+ProxyPreserveHost On
+
++RequestHeader set X-Forwarded-Proto "https"
+
+ProxyPass /ws/ ws://localhost:8000/ws/
+ProxyPassReverse /ws/ ws://localhost:8000/ws/
+
+ProxyPass / http://127.0.0.1:8000/
+ProxyPassReverse / http://127.0.0.1:8000/
+```
+
+Debes configurar Apache para habilitar actualizaciones de sockets web.
+
+```diff
+ProxyPreserveHost On
+
+RequestHeader set X-Forwarded-Proto "https"
+
++ProxyPass /ws/ ws://localhost:8000/ws/
++ProxyPassReverse /ws/ ws://localhost:8000/ws/
+
+ProxyPass / http://127.0.0.1:8000/
+ProxyPassReverse / http://127.0.0.1:8000/
+```

--- a/content/install/server/caddy.es.md
+++ b/content/install/server/caddy.es.md
@@ -9,7 +9,7 @@ url = "setup-with-caddy"
   weight = 4
 +++
 
-Esta guía provee un vistazo corto a la instalación de un servidor de Drone detrás de un servidor web Caddy. Éste es un archivo de configuración de proxy en caddy:
+Esta guía provee un vistazo rápido a la instalación de un servidor de Drone detrás de un servidor web Caddy. Éste es un archivo de configuración de proxy en Caddy:
 
 ```nohighlight
 drone.mycompany.com {
@@ -23,7 +23,7 @@ drone.mycompany.com {
 }
 ```
 
-Debe deshabilitar la compresión gzip para datos contínuos de lo contrario las actualizaciones en vivo no serán instantáneas:
+Debe deshabilitar la compresión gzip para datos en stream, de lo contrario las actualizaciones en tiempo real no serán instantáneas:
 
 ```diff
 drone.mycomopany.com {

--- a/content/install/server/caddy.es.md
+++ b/content/install/server/caddy.es.md
@@ -1,0 +1,66 @@
++++
+date = "2017-04-15T14:39:04+02:00"
+title = "Configuración con Caddy"
+url = "setup-with-caddy"
+
+[menu.install]
+  identifier = "setup-with-caddy"
+  parent = "install_server"
+  weight = 4
++++
+
+Esta guía provee un vistazo corto a la instalación de un servidor de Drone detrás de un servidor web Caddy. Éste es un archivo de configuración de proxy en caddy:
+
+```nohighlight
+drone.mycompany.com {
+    gzip {
+        not /stream/
+    }
+    proxy / localhost:8000 {
+        websocket
+        transparent
+    }
+}
+```
+
+Debe deshabilitar la compresión gzip para datos contínuos de lo contrario las actualizaciones en vivo no serán instantáneas:
+
+```diff
+drone.mycomopany.com {
++   gzip {
++       not /stream/
++   }
+    proxy / localhost:8000 {
+        websocket
+        transparent
+    }
+}
+```
+
+Debes configurar el proxy para habilitar la actualización de sockets web:
+
+```diff
+drone.mycompany.com {
+    gzip {
+        not /stream/
+    }
+    proxy / localhost:8000 {
++       websocket
+        transparent
+    }
+}
+```
+
+Debes configurar el proxy para incluir cabeceras `X-Forwarded` usando la directiva `transparent`:
+
+```diff
+drone.mycompany.com {
+    gzip {
+        not /stream/
+    }
+    proxy / localhost:8000 {
+        websocket
++       transparent
+    }
+}
+```

--- a/content/install/server/database.es.md
+++ b/content/install/server/database.es.md
@@ -43,7 +43,7 @@ services:
 
 # Creación de la base de datos
 
-Drone no crea la base de datos automáticamente. Si estas usando el controlador de mysql o postgres es necesario crear la base de datos usando el comando `CREATE DATABASE`
+Drone no crea la base de datos automáticamente. Si estas usando el controlador de MySQL o Postgres es necesario crear la base de datos usando el comando `CREATE DATABASE`
 
 # Migración de la base de datos
 

--- a/content/install/server/database.es.md
+++ b/content/install/server/database.es.md
@@ -9,11 +9,11 @@ url = "database-settings"
   weight = 1
 +++
 
-Esta guía provee instrucciones para usar motores de almacenaje alternativos. Por favor nota que esto es opcional. El motor de almacenaje por defecto es una base de datos SQLite embebida que no requiere instalarse o configurarse.
+Esta guía provee instrucciones para usar motores de base de datos. Por favor nota que esto es opcional. El motor de almacenaje por defecto es una base de datos SQLite embebida que no requiere instalarse o configurarse.
 
 # Configurar MySQL
 
-El siguiente ejemplo demuestra la configuración de una base de datos mysql. Revisa la [documentación del controlador oficial](https://github.com/go-sql-driver/mysql#dsn-data-source-name) para encontrar opciones de configuración y otros ejemplos.
+El siguiente ejemplo demuestra la configuración de una base de datos MySQL. Revisa la [documentación del controlador oficial](https://github.com/go-sql-driver/mysql#dsn-data-source-name) para encontrar opciones de configuración y otros ejemplos.
 
 ```diff
 version: '2'
@@ -28,7 +28,7 @@ services:
 
 # Configurar Postgres
 
-El siguiente ejemplo muestra la configuración de una base de datos postgres. Revisa la [documentación del controlador oficial](https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING) para encontrar opciones de configuración y otros ejemplos.
+El siguiente ejemplo muestra la configuración de una base de datos Postgres. Revisa la [documentación del controlador oficial](https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING) para encontrar opciones de configuración y otros ejemplos.
 
 ```diff
 version: '2'
@@ -47,12 +47,12 @@ Drone no crea la base de datos automáticamente. Si estas usando el controlador 
 
 # Migración de la base de datos
 
-Drone maneja la migración de la base de datos automáticamente, incluyendo la creación inicial de tablas e índices. Nuevas version de Drone actualizarán la base de datos a menos que se indique en las notas de lanzamiento.
+Drone maneja la migración de la base de datos automáticamente, incluyendo la creación inicial de tablas e índices. Nuevas versiones de Drone actualizarán la base de datos a menos que se indique en las notas de lanzamiento.
 
 # Respaldos de la base de datos
 
-Drone no realiza respaldos de la base de datos. Esto debería se manejado por herramientas de terceras entidades proveídas por el vendedor de base de datos elegido.
+Drone no realiza respaldos de la base de datos. Esto debería se manejado por herramientas externas proveídas por el vendedor de base de datos elegido.
 
 # Archivando la base de datos
 
-Drone no archiva datos; se considera fuera del alcance del proyecto. Drone es algo conservador con la cantidad de datos que guarda, sin embargo, deberías esperar que los logs de la base de datos incrementen el tamaño de tu base de datos considerablemente.
+Drone no archiva datos; se considera fuera del alcance del proyecto. Drone es algo conservador con la cantidad de datos que guarda, sin embargo, deberías asumir que los logs de la base de datos incrementen el tamaño de tu base de datos considerablemente.

--- a/content/install/server/database.es.md
+++ b/content/install/server/database.es.md
@@ -1,0 +1,58 @@
++++
+date = "2017-04-15T14:39:04+02:00"
+title = "Configuraciones de base de datos"
+url = "database-settings"
+
+[menu.install]
+  identifier = "database-settings"
+  parent = "install_server"
+  weight = 1
++++
+
+Esta guía provee instrucciones para usar motores de almacenaje alternativos. Por favor nota que esto es opcional. El motor de almacenaje por defecto es una base de datos SQLite embebida que no requiere instalarse o configurarse.
+
+# Configurar MySQL
+
+El siguiente ejemplo demuestra la configuración de una base de datos mysql. Revisa la [documentación del controlador oficial](https://github.com/go-sql-driver/mysql#dsn-data-source-name) para encontrar opciones de configuración y otros ejemplos.
+
+```diff
+version: '2'
+
+services:
+  drone-server:
+    image: drone/drone:{{% version %}}
+    environment:
++     DRONE_DATABASE_DRIVER: mysql
++     DRONE_DATABASE_DATASOURCE: root:password@tcp(1.2.3.4:3306)/drone?parseTime=true
+```
+
+# Configurar Postgres
+
+El siguiente ejemplo muestra la configuración de una base de datos postgres. Revisa la [documentación del controlador oficial](https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING) para encontrar opciones de configuración y otros ejemplos.
+
+```diff
+version: '2'
+
+services:
+  drone-server:
+    image: drone/drone:{{% version %}}
+    environment:
++     DRONE_DATABASE_DRIVER: postgres
++     DRONE_DATABASE_DATASOURCE: postgres://root:password@1.2.3.4:5432/postgres?sslmode=disable
+```
+
+# Creación de la base de datos
+
+Drone no crea la base de datos automáticamente. Si estas usando el controlador de mysql o postgres es necesario crear la base de datos usando el comando `CREATE DATABASE`
+
+# Migración de la base de datos
+
+Drone maneja la migración de la base de datos automáticamente, incluyendo la creación inicial de tablas e índices. Nuevas version de Drone actualizarán la base de datos a menos que se indique en las notas de lanzamiento.
+
+# Respaldos de la base de datos
+
+Drone no realiza respaldos de la base de datos. Esto debería se manejado por herramientas de terceras entidades proveídas por el vendedor de base de datos elegido.
+
+# Archivando la base de datos
+
+Drone no archiva datos; se considera fuera del alcance del proyecto. Drone es algo conservador con la cantidad de datos que guarda, sin embargo, deberías esperar que los logs de la base de datos incrementen el tamaño de tu base de datos considerablemente.

--- a/content/install/server/lets_encrypt.es.md
+++ b/content/install/server/lets_encrypt.es.md
@@ -9,7 +9,7 @@ url = "configure-lets-encrypt"
   weight = 9
 +++
 
-Drone soporta la configuración y actualización automatizada de ssl usando let's encrypt. Puedes habilitar let's encrypt haciendo las siguientes modificaciones a la configuración de tu servidor:
+Drone soporta la configuración y actualización automatizada de SSL usando Let's Encrypt. Puedes habilitar Let's Encrypt haciendo las siguientes modificaciones a la configuración de tu servidor:
 
 ```diff
 services:
@@ -32,13 +32,13 @@ services:
 +     - DRONE_LETS_ENCRYPT=true
 ```
 
-Nota que Drone usa el hostname de la varialbe de entorno `DRONE_HOST`cuando se soliciten los certificados. Por ejemplo, para `DRONE_HOST=https://foo.com` el certificado solicitado será `foo.com`.
+Nota que Drone usa el hostname de la variable de entorno `DRONE_HOST`cuando se soliciten los certificados. Por ejemplo, para `DRONE_HOST=https://foo.com` el certificado solicitado será para el dominio `foo.com`.
 
 <!-- Once enabled you can visit your website at both the http and the https address. There are no immediate plans to redirect from http to https, but it may be considered for a future release. -->
 
 # Caché de certificados
 
-Drone escribe los certificados al siguiente directorio:
+Drone almacenará los certificados al siguiente directorio:
 
 ```
 /var/lib/drone/golang-autocert
@@ -46,4 +46,4 @@ Drone escribe los certificados al siguiente directorio:
 
 # Actualizaciones de certificados
 
-Drone usa la librería oficial de Go acme que maneja las actualizaciones de certificados. No debería requerirse configuración o manejo adicional.
+Drone usa la librería oficial de Go ACME que maneja las actualizaciones de certificados. No debería requerirse configuración o manejo adicional.

--- a/content/install/server/lets_encrypt.es.md
+++ b/content/install/server/lets_encrypt.es.md
@@ -1,0 +1,49 @@
++++
+date = "2017-04-15T14:39:04+02:00"
+title = "Configurar Lets Encrypt"
+url = "configure-lets-encrypt"
+
+[menu.install]
+  identifier = "configure-lets-encrypt"
+  parent = "install_server"
+  weight = 9
++++
+
+Drone soporta la configuración y actualización automatizada de ssl usando let's encrypt. Puedes habilitar let's encrypt haciendo las siguientes modificaciones a la configuración de tu servidor:
+
+```diff
+services:
+  drone-server:
+    image: drone/drone:{{% version %}}
+    ports:
++     - 80:80
++     - 443:443
+      - 9000:9000
+    volumes:
+      - /var/lib/drone:/var/lib/drone/
+    restart: always
+    environment:
+      - DRONE_OPEN=true
+      - DRONE_HOST=${DRONE_HOST}
+      - DRONE_GITHUB=true
+      - DRONE_GITHUB_CLIENT=${DRONE_GITHUB_CLIENT}
+      - DRONE_GITHUB_SECRET=${DRONE_GITHUB_SECRET}
+      - DRONE_SECRET=${DRONE_SECRET}
++     - DRONE_LETS_ENCRYPT=true
+```
+
+Nota que Drone usa el hostname de la varialbe de entorno `DRONE_HOST`cuando se soliciten los certificados. Por ejemplo, para `DRONE_HOST=https://foo.com` el certificado solicitado será `foo.com`.
+
+<!-- Once enabled you can visit your website at both the http and the https address. There are no immediate plans to redirect from http to https, but it may be considered for a future release. -->
+
+# Caché de certificados
+
+Drone escribe los certificados al siguiente directorio:
+
+```
+/var/lib/drone/golang-autocert
+```
+
+# Actualizaciones de certificados
+
+Drone usa la librería oficial de Go acme que maneja las actualizaciones de certificados. No debería requerirse configuración o manejo adicional.

--- a/content/install/server/nginx.es.md
+++ b/content/install/server/nginx.es.md
@@ -1,6 +1,6 @@
 +++
 date = "2017-04-15T14:39:04+02:00"
-title = "Configuración con nginx"
+title = "Configuración con Nginx"
 url = "setup-with-nginx"
 
 [menu.install]
@@ -9,7 +9,7 @@ url = "setup-with-nginx"
   weight = 3
 +++
 
-Esta guía provee un vistazo básico para instalar un servidor de Drone detrás de un servidor web nginx. Para obtener opciones de configuración más avanzadas por favor consulta la [documentación oficial](https://www.nginx.com/resources/admin-guide/) de nginx.
+Esta guía provee un vistazo básico para instalar un servidor de Drone detrás de un servidor web Nginx. Para obtener opciones de configuración más avanzadas por favor consulta la [documentación oficial](https://www.nginx.com/resources/admin-guide/) de Nginx.
 
 Configuración de ejemplo:
 

--- a/content/install/server/nginx.es.md
+++ b/content/install/server/nginx.es.md
@@ -1,0 +1,122 @@
++++
+date = "2017-04-15T14:39:04+02:00"
+title = "Configuración con nginx"
+url = "setup-with-nginx"
+
+[menu.install]
+  identifier = "setup-with-nginx"
+  parent = "install_server"
+  weight = 3
++++
+
+Esta guía provee un vistazo básico para instalar un servidor de Drone detrás de un servidor web nginx. Para obtener opciones de configuración más avanzadas por favor consulta la [documentación oficial](https://www.nginx.com/resources/admin-guide/) de nginx.
+
+Configuración de ejemplo:
+
+```nginx
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 80;
+    server_name drone.example.com;
+
+    location / {
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $http_host;
+
+        proxy_pass http://127.0.0.1:8000;
+        proxy_redirect off;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+
+        chunked_transfer_encoding off;
+    }
+
+    location ~* /ws {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 86400;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $http_host;
+    }
+}
+```
+
+Debes configurar el proxy con cabeceras `X-Forwarded`:
+
+```diff
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 80;
+    server_name drone.example.com;
+
+    location / {
++       proxy_set_header X-Forwarded-For $remote_addr;
++       proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_pass http://127.0.0.1:8000;
+        proxy_redirect off;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+
+        chunked_transfer_encoding off;
+    }
+
+    location ~* /ws {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 86400;
++       proxy_set_header X-Forwarded-For $remote_addr;
++       proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+Debes configurar Nginx para actualizar sockets web.
+
+```diff
++map $http_upgrade $connection_upgrade {
++    default upgrade;
++    ''      close;
++}
+
+server {
+    listen 80;
+    server_name drone.example.com;
+
+    location / {
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_pass http://127.0.0.1:8000;
+        proxy_redirect off;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+
+        chunked_transfer_encoding off;
+    }
+
+    location ~* /ws {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_http_version 1.1;
++       proxy_set_header Upgrade $http_upgrade;
++       proxy_set_header Connection "upgrade";
+        proxy_read_timeout 86400;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```

--- a/content/install/server/ngrok.es.md
+++ b/content/install/server/ngrok.es.md
@@ -1,0 +1,14 @@
++++
+date = "2017-04-15T14:39:04+02:00"
+title = "Configuración con Ngrok"
+url = "setup-with-ngrok"
+
+[menu.install]
+  identifier = "setup-with-ngrok"
+  parent = "install_server"
+  weight = 6
++++
+
+{{% alert warn %}}
+Instrucciones próximamente
+{{% /alert %}}

--- a/content/install/server/ssl.es.md
+++ b/content/install/server/ssl.es.md
@@ -1,0 +1,88 @@
++++
+date = "2017-04-15T14:39:04+02:00"
+title = "Configurar SSL"
+url = "configure-ssl"
+
+[menu.install]
+  identifier = "configure-ssl"
+  parent = "install_server"
+  weight = 10
++++
+
+Drone soporta configuración ssl montando certificados en tu contenedor. Nota que también existe soporte para [Lets Encrypt]({{< relref "lets_encrypt.md" >}}) automatizado.
+
+```diff
+services:
+  drone-server:
+    image: drone/drone:{{% version %}}
+    ports:
++     - 80:80
++     - 443:443
+      - 9000:9000
+    volumes:
+      - /var/lib/drone:/var/lib/drone/
++     - /etc/certs/drone.foo.com/server.crt:/etc/certs/drone.foo.com/server.crt
++     - /etc/certs/drone.foo.com/server.key:/etc/certs/drone.foo.com/server.key
+    restart: always
+    environment:
++     - DRONE_SERVER_CERT=/etc/certs/drone.foo.com/server.crt
++     - DRONE_SERVER_KEY=/etc/certs/drone.foo.com/server.key
+```
+
+Actualiza tu configuración para exponer los siguientes puertos:
+
+```diff
+services:
+  drone-server:
+    image: drone/drone:{{% version %}}
+    ports:
++     - 80:80
++     - 443:443
+      - 9000:9000
+```
+
+Actualiza tu configuración para montar tu certificado y llave:
+
+```diff
+services:
+  drone-server:
+    image: drone/drone:{{% version %}}
+    ports:
+      - 80:80
+      - 443:443
+      - 9000:9000
+    volumes:
+      - /var/lib/drone:/var/lib/drone/
++     - /etc/certs/drone.foo.com/server.crt:/etc/certs/drone.foo.com/server.crt
++     - /etc/certs/drone.foo.com/server.key:/etc/certs/drone.foo.com/server.key
+```
+
+Actualiza tu configuración para proveer las rutas de acceso de tu certificado y llave:
+
+```diff
+services:
+  drone-server:
+    image: drone/drone:{{% version %}}
+    ports:
+      - 80:80
+      - 443:443
+      - 9000:9000
+    volumes:
+      - /var/lib/drone:/var/lib/drone/
+      - /etc/certs/drone.foo.com/server.crt:/etc/certs/drone.foo.com/server.crt
+      - /etc/certs/drone.foo.com/server.key:/etc/certs/drone.foo.com/server.key
+    restart: always
+    environment:
++     - DRONE_SERVER_CERT=/etc/certs/drone.foo.com/server.crt
++     - DRONE_SERVER_KEY=/etc/certs/drone.foo.com/server.key
+```
+
+# Cadena de certificados
+
+El problema más común es proveer un certificado sin la cadena intermedia.
+
+> LoadX509KeyPair lee y analiza un par de llaves públicas/privadas de un par de archivos. Los archivos deben contener datos codificados en PEM. El archivo de certificado puede contener certificados intermedios después del certificado hoja formando una cadena de certificados.
+
+# Errores de certificado
+
+El soporte SSL es proveído usando la función [ListenAndServeTLS](https://golang.org/pkg/net/http/#ListenAndServeTLS) de la librería estándas de Go. Si recibes error o advertencias de certificado por favor examina tu configuración con más detalle. Por favor no crea issues mencionando que SSL está roto.

--- a/content/install/server/ssl.es.md
+++ b/content/install/server/ssl.es.md
@@ -9,7 +9,7 @@ url = "configure-ssl"
   weight = 10
 +++
 
-Drone soporta configuración ssl montando certificados en tu contenedor. Nota que también existe soporte para [Lets Encrypt]({{< relref "lets_encrypt.md" >}}) automatizado.
+Drone soporta configuración SSL montando certificados en tu contenedor. Nota que también existe soporte para [Let's Encrypt]({{< relref "lets_encrypt.md" >}}) automatizado.
 
 ```diff
 services:
@@ -79,10 +79,10 @@ services:
 
 # Cadena de certificados
 
-El problema más común es proveer un certificado sin la cadena intermedia.
+El problema más común es proveer un certificado sin la cadena intermediaria.
 
-> LoadX509KeyPair lee y analiza un par de llaves públicas/privadas de un par de archivos. Los archivos deben contener datos codificados en PEM. El archivo de certificado puede contener certificados intermedios después del certificado hoja formando una cadena de certificados.
+> LoadX509KeyPair lee y analiza un par de llaves públicas/privadas de un par de archivos. Los archivos deben contener datos codificados en PEM. El archivo de certificado puede contener certificados intermedios después del certificado hoja resultando en una cadena de certificados.
 
 # Errores de certificado
 
-El soporte SSL es proveído usando la función [ListenAndServeTLS](https://golang.org/pkg/net/http/#ListenAndServeTLS) de la librería estándas de Go. Si recibes error o advertencias de certificado por favor examina tu configuración con más detalle. Por favor no crea issues mencionando que SSL está roto.
+El soporte SSL es proveído usando la función [ListenAndServeTLS](https://golang.org/pkg/net/http/#ListenAndServeTLS) de la librería estándar de Go. Si recibes errores o advertencias de certificado por favor examina tu configuración a más detalle. Por favor no crees issues mencionando que SSL está roto.

--- a/content/install/users/user_admins.es.md
+++ b/content/install/users/user_admins.es.md
@@ -9,7 +9,7 @@ url = "es/user-admins"
   parent = "install_access"
 +++
 
-Puedes conceder privilegios administrativos a usuarios proveyedo una lista separada por comas de usuarios, usando la variable de ambiente designada.
+Puedes conceder privilegios administrativos a usuarios proveyendo una lista separada por comas de usuarios, usando la variable de ambiente designada.
 
 ```diff
 services:
@@ -19,4 +19,4 @@ services:
 +     - DRONE_ADMIN=janedoe,johnsmith
 ```
 
-Por favor nota que los nombre de usuarios son sensibles entre mayúsuculas y minúsculas, y deben coincidir exactamente con los valores retornados con tu sistema de control de versiones (Ej Github).
+Por favor nota que los nombre de usuarios son sensibles entre mayúsculas y minúsculas, y deben coincidir exactamente con los valores retornados con tu sistema de control de versiones (Ej Github).

--- a/content/install/users/user_management.es.md
+++ b/content/install/users/user_management.es.md
@@ -9,7 +9,7 @@ url = "es/user-management"
   parent = "install_access"
 +++
 
-Puedes manualmente manejar el registro de usuarios usando la utilidad de línea de comandos. Por favor mira la documentación de la utilidad de línea de comandos para instalar y configurar la utilidad de línea de comandos.
+Puedes manejar el registro de usuarios manualmente usando la utilidad de línea de comandos. Por favor mira la documentación de la utilidad de línea de comandos para instalar y configurar la utilidad de línea de comandos.
 
 Usa el comando `ls` para listar todos los usuarios activos:
 
@@ -23,13 +23,13 @@ Usa el comando `add` para agregar usuarios al sistema por nombre de usuario:
 drone user add octocat
 ```
 
-Usa el comando `rm` para eliminar usuarios del sistema por nombre d eusuario:
+Usa el comando `rm` para eliminar usuarios del sistema por nombre de usuario:
 
 ```nohighlight
 drone user rm octocat
 ```
 
-Por favor nota que solamente los administradores pueden manejar usuarios. Por en el ejemplo que mostraremos a continuación configuraremos varios administradores separados por coma, usando la variable de ambiente correspondiente.
+Por favor nota que solamente los administradores pueden manejar usuarios. En el ejemplo que mostraremos a continuación configuraremos varios administradores separados por coma, usando la variable de ambiente correspondiente.
 
 ```diff
 services:


### PR DESCRIPTION
The `SERVER SETUP` section is now translated to Spanish. This includes setups with Caddy, Apache, Let's Encrypt and the rest.

This continues the work from @patrickdappollonio and @ma0c. If any of you can review the translations and suggest any change I'd be happy to work on it.

Thanks!