### PR TITLE
Add note about using secrets locally with drone exec

### DIFF
--- a/content/cli/misc/drone_exec.md
+++ b/content/cli/misc/drone_exec.md
@@ -9,6 +9,14 @@ url = "cli-exec"
   parent = "cli_misc"
 +++
 
+This subcommand executes a local build.
+
 ```text
 {{< cat "content/cli/misc/data/drone_exec.out.txt" >}}
+```
+
+If your pipeline uses secrets, these can be injected locally simply by passing environment variables:
+
+```text
+$ MY_SECRET=mybigsecret drone exec
 ```


### PR DESCRIPTION
## Description

With the current documentation, it is not clear that secrets can still be injected `drone exec`, given the removal of the `--secret` option from the CLI. As per [this comment on discourse](https://discourse.drone.io/t/solved-secrets-not-available-to-drone-exec-local/270/4), this can be achieved by passing environment variables to the exec command.

## Changes

* Added note to the documentation to reflect the above information.