### PR TITLE
Link to GitHub app registration page

### DIFF
--- a/content/install/installation_overview.md
+++ b/content/install/installation_overview.md
@@ -55,7 +55,7 @@ services:
 Drone does not have any builtin user management. Instead, authentication is done using OAuth and is delegated to one of multiple version control providers, configured using environment variables. The example above demonstrates basic GitHub integration.
 
 {{% alert %}}
-You must register Drone with GitHub to obtain the `DRONE_GITHUB_CLIENT` and `DRONE_GITHUB_SECRET` used above. The authorization callback url must match `<scheme>://<host>/authorize`.
+You must [register Drone with GitHub](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/) to obtain the `DRONE_GITHUB_CLIENT` and `DRONE_GITHUB_SECRET` used above. The authorization callback url must match `<scheme>://<host>/authorize`.
 
 You can register Drone as a user or organizational OAuth App.
 {{% /alert %}}

--- a/content/install/installation_overview.md
+++ b/content/install/installation_overview.md
@@ -52,10 +52,10 @@ services:
       - DRONE_SECRET=${DRONE_SECRET}
 ```
 
-Drone integrates with multiple version control providers, configured using environment variables. This example demonstrates basic GitHub integration.
+Drone does not have any builtin user management. Instead, authentication is done using OAuth and is delegated to one of multiple version control providers, configured using environment variables. The example above demonstrates basic GitHub integration.
 
 {{% alert %}}
-You must register Drone with GitHub to obtain the client and secret. The authorization callback url must match `<scheme>://<host>/authorize`
+You must [register Drone with GitHub](https://github.com/settings/applications/new) to obtain the `DRONE_GITHUB_CLIENT` and `DRONE_GITHUB_SECRET` used above. The authorization callback url must match `<scheme>://<host>/authorize`. 
 {{% /alert %}}
 
 ```diff

--- a/content/install/installation_overview.md
+++ b/content/install/installation_overview.md
@@ -55,7 +55,9 @@ services:
 Drone does not have any builtin user management. Instead, authentication is done using OAuth and is delegated to one of multiple version control providers, configured using environment variables. The example above demonstrates basic GitHub integration.
 
 {{% alert %}}
-You must [register Drone with GitHub](https://github.com/settings/applications/new) to obtain the `DRONE_GITHUB_CLIENT` and `DRONE_GITHUB_SECRET` used above. The authorization callback url must match `<scheme>://<host>/authorize`. 
+You must register Drone with GitHub to obtain the `DRONE_GITHUB_CLIENT` and `DRONE_GITHUB_SECRET` used above. The authorization callback url must match `<scheme>://<host>/authorize`.
+
+You can register Drone as a user or organizational OAuth App.
 {{% /alert %}}
 
 ```diff


### PR DESCRIPTION
Explain why one would want to register with GitHub. Before the documentation was not really clear on this: "register Drone with GitHub" was not at all clear to me since I had never used GitHub as an OAuth provider before.