### PR TITLE
Add docs on instance condition

### DIFF
--- a/content/usage/config/conditions.md
+++ b/content/usage/config/conditions.md
@@ -130,3 +130,12 @@ when:
     GO_VERSION: 1.5
     REDIS_VERSION: 2.8
 ```
+
+# Instance
+
+Execute a step only on certain Drone instance:
+
+```diff
+when:
+  instance: stage.drone.company.com
+```


### PR DESCRIPTION
This is helpful if you want to only run certain steps on certain drone instances (e.g. you have a Drone server in production and staging).