### PR TITLE
Add information about global config ordering

### DIFF
--- a/content/usage/secrets/registries_global.md
+++ b/content/usage/secrets/registries_global.md
@@ -46,3 +46,9 @@ Example registry credentials file:
       "type": "..."
     }
 ```
+
+{{% alert info %}}
+Credentials configured via global registries take precedence over credentials configured in individual repositories.
+
+* This is expected to reverse in Drone 0.8.4.
+{{% /alert %}}

--- a/content/usage/secrets/secrets_global.md
+++ b/content/usage/secrets/secrets_global.md
@@ -38,6 +38,10 @@ Example secrets file:
   value: correct-horse-batter-staple
 ```
 
+{{% alert info %}}
+Secrets configured via global secrets take precedence over secrets configured in individual repositories.
+{{% /alert %}}
+
 # Restricting Access
 
 Restrict access to global secrets based on repository name using the `repos` attribute. This is defined as an array list with glob support.


### PR DESCRIPTION
Is it ok to have the `*` for the upcoming changes to registries?