### PR TITLE
Fixed host string in mysql document

### DIFF
--- a/content/usage/examples/mysql.md
+++ b/content/usage/examples/mysql.md
@@ -67,6 +67,6 @@ services:
 If you are still unable to connect to the mysql container, please make sure you are using the service name as the hostname.
 
 ```diff
-- mysql -u root -h 127.0.0.1:3306
-+ mysql -u root -h tcp://database:3306
+- mysql -u root -h 127.0.0.1
++ mysql -u root -h database
 ```


### PR DESCRIPTION
With the commands provided in current document, I got the error:

```sh
ERROR 2005 (HY000): Unknown MySQL server host 'tcp://database:3306'
```