### PR TITLE
Try to make the global secret/registry docs more consistent

### DIFF
--- a/content/install/extensions/global_registries.md
+++ b/content/install/extensions/global_registries.md
@@ -60,3 +60,9 @@ Example registry credentials for an ECR repository:
   aws_access_key_id: a50d28f4dd477bc184fbd10b376de753
   aws_secret_access_key: bc5785d3ece6a9cdefa42eb99b58986f9095ff1c
 ```
+
+# Restricting Access
+
+Currently, global registry credentials do not support any attribute-based usage restriction (repo, images, events).
+
+This is because registry credentials are internal-only to Drone, and unlike secrets, are never exposed to the build.

--- a/content/install/extensions/global_registries.md
+++ b/content/install/extensions/global_registries.md
@@ -53,7 +53,7 @@ Example registry credentials file:
 
 The global registry file supports elastic container registries. Temporary authentication credentials are automatically generated and refreshed using the GetAuthorizationToken endpoint. Note that you must provide your aws access key and secret, and configure the appropriate IAM roles.
 
-Example registry credentials for an ecr repository:
+Example registry credentials for an ECR repository:
 
 ```nohighlight
 - address: 012345678910.dkr.ecr.us-east-1.amazonaws.com

--- a/content/install/extensions/global_secrets.md
+++ b/content/install/extensions/global_secrets.md
@@ -31,7 +31,6 @@ services:
 +     DRONE_GLOBAL_SECRETS=/etc/drone-secrets.yml
 ```
 
-
 Example secrets file:
 
 ```nohighlight
@@ -65,15 +64,29 @@ Restrict access to global secrets based on image name using the `images` attribu
   images: [ plugins/docker:latest, plugins/ecr:* ]
 ```
 
-Both restrictions can be combined.
+Restrict access to global secrets based on event name using the `events` attribute.
+
+```
+- name: docker_username
+  value: octocat
+  events: [ push, pull_request ]
+- name: docker_password
+  value: correct-horse-battery-staple
+  events: [ push, tag ]
+```
+
+Any combination of restrictions can be combined.
 
 ```
 - name: docker_username
   value: octocat
   repos: [ octocat/hello-world, github/* ]
+  events: [ push, tag ]
   images: [ plugins/* ]
 - name: docker_password
   value: correct-horse-battery-staple
   repos: [ octocat/hello-world, github/* ]
   images: [ plugins/docker ]
 ```
+
+Currently, global secrets does not support `status` as an attribute-based usage restriction.

--- a/content/install/extensions/integrate_vault.md
+++ b/content/install/extensions/integrate_vault.md
@@ -50,6 +50,8 @@ Please note that you must provide drone with the root token at this time. We are
 # Amazon IAM
 -->
 
-# Usage
+# Restricting Access
 
-Please see the vault usage [documentation]({{< ref "usage/secrets/secrets_vault.md" >}}) which include details usage instructions for creating and consuming vault secrets in your pipelines.
+Secrets sourced from vault are restricted using key-values associated with the secret.
+
+Please see the vault usage [documentation]({{< ref "usage/secrets/secrets_vault.md" >}}) for detailed usage instructions for creating and consuming vault secrets in your pipelines.

--- a/content/usage/secrets/registries_global.md
+++ b/content/usage/secrets/registries_global.md
@@ -10,52 +10,21 @@ menu:
 ---
 
 {{% alert enterprise %}}
-This feature is only available in the [Enterprise Edition](https://drone.io/enterprise/)
+This feature is only available in the [Enterprise expansion pack](https://drone.io/enterprise/)
 {{% /alert %}}
 
-The enterprise edition supports global registry credentials, sourced from a yaml file on your server. You should mount the registry credentials file into your container and specify the path to the file in your configuration.
+The enterprise expansion pack provides support for global registry credentials, sourced from a yaml file on your server. You should mount the credentials file into your container and specify the path to the file in your configuration.
 
-```diff
-services:
-  drone-server:
-    image: drone/drone:{{% version %}}
-    ports:
-      - 80:8000
-    volumes:
-      - /var/lib/drone:/var/lib/drone/
-+     - /etc/drone-registry.yml:/etc/drone-registry.yml
-    restart: always
-    environment:
-+     DRONE_GLOBAL_REGISTRY=/etc/drone-registry.yml
-```
+# Configuration
 
-Example registry credentials file:
+Please see [the installation notes]({{<relref "install/extensions/global_registries.md">}}) to configure global registries file and its restrictions.
 
-```nohighlight
-- address: docker.io
-  username: octocat
-  password: correct-horse-batter-staple
-- address: gcr.io
-  username: _json_key
-  password: |
-    {
-      "private_key_id": "...",
-      "private_key": "...",
-      "client_email": "...",
-      "client_id": "...",
-      "type": "..."
-    }
-```
+# Precedence
 
 {{% alert info %}}
 Credentials configured via *individual repositories* take precedence over credentials configured in global registries.
-
-In versions < `0.8.4`, credentials configured via *global registries* take precedence over credentials configured in individual repositories.
-
 {{% /alert %}}
 
-# Restricting Access
-
-Currently, global registry credentials do not support any attribute-based usage restriction (repo, images, events).
-
-This is because registry credentials are internal-only to Drone, and unlike secrets, are never exposed to the build.
+{{% alert warn %}}
+In versions < `0.8.4`, credentials configured via *global registries* take precedence over credentials configured in individual repositories.
+{{% /alert %}}

--- a/content/usage/secrets/registries_global.md
+++ b/content/usage/secrets/registries_global.md
@@ -1,10 +1,10 @@
 ---
-title: Global Registries
+title: Global Registry Credentials
 url: global-registries
 
 menu:
   usage:
-    weight: 4
+    weight: 2
     identifier: global-registries
     parent: usage_secrets
 ---

--- a/content/usage/secrets/registries_global.md
+++ b/content/usage/secrets/registries_global.md
@@ -28,3 +28,7 @@ Credentials configured via *individual repositories* take precedence over creden
 {{% alert warn %}}
 In versions < `0.8.4`, credentials configured via *global registries* take precedence over credentials configured in individual repositories.
 {{% /alert %}}
+
+# Usage
+
+Usage notes about [registry credentials]({{<relref "registries.md">}}) apply for global registry credentials as well.

--- a/content/usage/secrets/secrets.md
+++ b/content/usage/secrets/secrets.md
@@ -4,7 +4,7 @@ url: manage-secrets
 
 menu:
   usage:
-    weight: 2
+    weight: 3
     identifier: manage_secrets
     parent: usage_secrets
 ---

--- a/content/usage/secrets/secrets.md
+++ b/content/usage/secrets/secrets.md
@@ -86,7 +86,6 @@ drone secret add \
 
 Please be careful when exposing secrets to pull requests. If your repository is open source and accepts pull requests your secrets are not safe. A bad actor can submit a malicious pull request that exposes your secrets. The recommended approach to secure secrets is to enable gated builds.
 
-
 # Examples
 
 Create the secret using default settings. The secret will be available to all images in your pipeline, and will be available to all push, tag, and deployment events (not pull request events).

--- a/content/usage/secrets/secrets_global.md
+++ b/content/usage/secrets/secrets_global.md
@@ -4,7 +4,7 @@ url: global-secrets
 
 menu:
   usage:
-    weight: 3
+    weight: 4
     identifier: global-secrets
     parent: usage_secrets
 ---

--- a/content/usage/secrets/secrets_global.md
+++ b/content/usage/secrets/secrets_global.md
@@ -24,3 +24,7 @@ Please see [the installation notes]({{<relref "install/extensions/global_secrets
 {{% alert info %}}
 Secrets configured via *global secrets* take precedence over secrets configured in individual repositories.
 {{% /alert %}}
+
+# Usage
+
+Usage notes about [secrets]({{<relref "registries.md">}}) apply for global secrets as well.

--- a/content/usage/secrets/secrets_global.md
+++ b/content/usage/secrets/secrets_global.md
@@ -10,85 +10,17 @@ menu:
 ---
 
 {{% alert enterprise %}}
-This feature is only available in the [Enterprise Edition](https://drone.io/enterprise/)
+This feature is only available in the [Enterprise expansion pack](https://drone.io/enterprise/)
 {{% /alert %}}
 
-The enterprise edition supports global secrets, sourced from a yaml file on your server. You should mount the secret file into your container and specify the path to the secret file in your configuration.
+The enterprise expansion pack provides support for global secrets variables, sourced from a yaml file on your server. You should mount the secrets file into your container and specify the path to the file in your configuration.
 
-```diff
-services:
-  drone-server:
-    image: drone/drone:{{% version %}}
-    ports:
-      - 80:8000
-    volumes:
-      - /var/lib/drone:/var/lib/drone/
-+     - /etc/drone-secrets.yml:/etc/drone-secrets.yml
-    restart: always
-    environment:
-+     DRONE_GLOBAL_SECRETS=/etc/drone-secrets.yml
-```
+# Configuration
 
-Example secrets file:
+Please see [the installation notes]({{<relref "install/extensions/global_secrets.md">}}) to configure global secrets file and its restrictions.
 
-```nohighlight
-- name: docker_username
-  value: octocat
-- name: docker_password
-  value: correct-horse-batter-staple
-```
+# Precedence
 
 {{% alert info %}}
 Secrets configured via *global secrets* take precedence over secrets configured in individual repositories.
 {{% /alert %}}
-
-# Restricting Access
-
-Restrict access to global secrets based on repository name using the `repos` attribute. This is defined as an array list with glob support.
-
-```
-- name: docker_username
-  value: octocat
-  repos: [ octocat/hello-world, github/* ]
-- name: docker_password
-  value: correct-horse-battery-staple
-  repos: [ octocat/hello-world, github/* ]
-```
-
-Restrict access to global secrets based on image name using the `images` attribute. This is defined as an array list with glob support.
-
-```
-- name: docker_username
-  value: octocat
-  images: [ plugins/docker, plugins/* ]
-- name: docker_password
-  value: correct-horse-battery-staple
-  images: [ plugins/docker:latest, plugins/ecr:* ]
-```
-
-Restrict access to global secrets based on event name using the `events` attribute.
-
-```
-- name: docker_username
-  value: octocat
-  events: [ push, pull_request ]
-- name: docker_password
-  value: correct-horse-battery-staple
-  events: [ push, tag ]
-```
-
-Any combination of restrictions can be combined.
-
-```
-- name: docker_username
-  value: octocat
-  repos: [ octocat/hello-world, github/* ]
-  events: [ push, tag ]
-  images: [ plugins/* ]
-- name: docker_password
-  value: correct-horse-battery-staple
-  repos: [ octocat/hello-world, github/* ]
-  images: [ plugins/docker ]
-```
-
-Currently, global secrets does not support `status` as an attribute-based usage restriction.

--- a/content/usage/secrets/secrets_vault.md
+++ b/content/usage/secrets/secrets_vault.md
@@ -15,45 +15,9 @@ This feature is only available in the [Enterprise Edition](https://drone.io/ente
 
 The enterprise edition supports loading secrets from [vault](https://www.vaultproject.io/). Note that vault credentials must be globally configured by an administrator. Vault secrets are declared in your yaml configuration file and loaded at runtime.
 
-Example configuration with vault secrets:
+# Usage
 
-```diff
-pipeline:
-  build:
-    image: golang
-    commands:
-      - go test
-      - go build
-  publish:
-    image: plugins/docker
-    repo: octocat/app
-    secrets: [ docker_username, docker_password ]
-
-secrets:
-  docker_username:
-    path: secret/docker_username
-  docker_password:
-    path: secret/docker_password
-```
-
-Secrets are added to vault using the vault command line utility. Secrets can be written to any valid path. See the below example:
-
-```nohighlight
-vault write secret/docker_username value=...
-vault write secret/docker_password value=...
-```
-
-The secrets paths can then be included in your yaml configuration:
-
-```diff
-secrets:
-  docker_username:
-    path: secret/docker_username
-  docker_password:
-    path: secret/docker_password
-```
-
-The vault secrets are passed to your pipeline steps by name. The below example requests the named secrets are passed to the pipeline step:
+Example configuration with vault secrets, passing them to the pipeline by name:
 
 ```diff
 pipeline:
@@ -67,6 +31,23 @@ pipeline:
     repo: octocat/app
 +   secrets: [ docker_username, docker_password ]
 
++secrets:
++  docker_username:
++    path: secret/docker_username
++  docker_password:
++    path: secret/docker_password
+```
+
+Add secrets to any valid path in vault using the vault command line utility:
+
+```nohighlight
+vault write secret/docker_username value=...
+vault write secret/docker_password value=...
+```
+
+Then include the secrets paths in your pipeline configuration:
+
+```diff
 secrets:
   docker_username:
     path: secret/docker_username
@@ -76,7 +57,7 @@ secrets:
 
 # Alternate Names
 
-In some cases the secret names in your vault instance may not match the names expected by the secrets. The secret names can be mapped to the correct values using the below syntax.
+In some cases the secret names in your vault instance may not match the names expected by the secrets. The secret names can be mapped to the correct values:
 
 ```diff
 pipeline:
@@ -95,13 +76,15 @@ pipeline:
 +       target: docker_password
 
 secrets:
-  username:
+- docker_username:
++ username:
     path: secret/docker_username
-  password:
+- docker_password:
++ password:
     path: secret/docker_password
 ```
 
-# Restricting Access
+# Restricting Repos
 
 You can restrict access to vault secrets based on repository name using the `repo` attribute. This is a comma-separated list with glob support.
 


### PR DESCRIPTION
Moved configuration docs to the installation section.
Kept developer usage docs in the usage section.
Moved access restriction docs next to the configuration it should be specified.
Removed duplicated information.

I did the refactoring with Hugo running locally.

PTAL @appleboy @tboerger.