### PR TITLE
bumped CLI version references to 0.8.3

### DIFF
--- a/content/cli/cli_overview.md
+++ b/content/cli/cli_overview.md
@@ -17,18 +17,18 @@ Download and install the raw binaries by platform:
 
 Platform    | Download
 ------------|---------
-Linux x64   | [tarball](https://github.com/drone/drone-cli/releases/download/v0.8.0/drone_linux_amd64.tar.gz)
-Linux arm64 | [tarball](https://github.com/drone/drone-cli/releases/download/v0.8.0/drone_linux_arm64.tar.gz)
-Linux arm   | [tarball](https://github.com/drone/drone-cli/releases/download/v0.8.0/drone_linux_arm.tar.gz)
-Windows x64 | [tarball](https://github.com/drone/drone-cli/releases/download/v0.8.0/drone_windows_amd64.tar.gz)
-Darwin x64  | [tarball](https://github.com/drone/drone-cli/releases/download/v0.8.0/drone_darwin_amd64.tar.gz)
+Linux x64   | [tarball](https://github.com/drone/drone-cli/releases/download/v0.8.3/drone_linux_amd64.tar.gz)
+Linux arm64 | [tarball](https://github.com/drone/drone-cli/releases/download/v0.8.3/drone_linux_arm64.tar.gz)
+Linux arm   | [tarball](https://github.com/drone/drone-cli/releases/download/v0.8.3/drone_linux_arm.tar.gz)
+Windows x64 | [tarball](https://github.com/drone/drone-cli/releases/download/v0.8.3/drone_windows_amd64.tar.gz)
+Darwin x64  | [tarball](https://github.com/drone/drone-cli/releases/download/v0.8.3/drone_darwin_amd64.tar.gz)
 
 # Install on Linux
 
 Download and install on Linux:
 
 ```nohighlight
-curl -L https://github.com/drone/drone-cli/releases/download/v0.8.0/drone_linux_amd64.tar.gz | tar zx
+curl -L https://github.com/drone/drone-cli/releases/download/v0.8.3/drone_linux_amd64.tar.gz | tar zx
 sudo install -t /usr/local/bin drone
 ```
 
@@ -37,7 +37,7 @@ sudo install -t /usr/local/bin drone
 Download and install on OSX:
 
 ```nohighlight
-curl -L https://github.com/drone/drone-cli/releases/download/v0.8.0/drone_darwin_amd64.tar.gz | tar zx
+curl -L https://github.com/drone/drone-cli/releases/download/v0.8.3/drone_darwin_amd64.tar.gz | tar zx
 sudo cp drone /usr/local/bin
 ```
 

--- a/content/cli/cli_overview.zh.md
+++ b/content/cli/cli_overview.zh.md
@@ -35,10 +35,10 @@ Darwin x64  | [tarball](https://github.com/drone/drone-cli/releases/)
 
 <!--Download and install on Linux:-->
 
-访问 https://github.com/drone/drone-cli/releases/ 了解最新版本号，可替换 v0.8.0 为最新版本。
+访问 https://github.com/drone/drone-cli/releases/ 了解最新版本号，可替换 v0.8.3 为最新版本。
 
 ```nohighlight
-curl -L https://github.com/drone/drone-cli/releases/download/v0.8.0/drone_linux_amd64.tar.gz | tar zx
+curl -L https://github.com/drone/drone-cli/releases/download/v0.8.3/drone_linux_amd64.tar.gz | tar zx
 sudo install -t /usr/local/bin drone
 ```
 
@@ -48,10 +48,10 @@ sudo install -t /usr/local/bin drone
 
 <!--Download and install on OSX:-->
 
-访问 https://github.com/drone/drone-cli/releases/ 了解最新版本号，可替换 v0.8.0 为最新版本。
+访问 https://github.com/drone/drone-cli/releases/ 了解最新版本号，可替换 v0.8.3 为最新版本。
 
 ```nohighlight
-curl -L https://github.com/drone/drone-cli/releases/download/v0.8.0/drone_darwin_amd64.tar.gz | tar zx
+curl -L https://github.com/drone/drone-cli/releases/download/v0.8.3/drone_darwin_amd64.tar.gz | tar zx
 sudo cp drone /usr/local/bin
 ```
 

--- a/content/install/releases/0.8.md
+++ b/content/install/releases/0.8.md
@@ -1,11 +1,11 @@
 +++
 date = "2017-04-15T14:39:04+02:00"
-title = "0.8.0"
-url = "release-0.8.0"
+title = "0.8.3"
+url = "release-0.8.3"
 
 [menu.install]
   weight = 80
-  identifier = "release-0.8.0"
+  identifier = "release-0.8.3"
   parent = "install_release"
 +++
 


### PR DESCRIPTION
Docs are pointing to 0.8.0 for the drone-cli, and I just ran into a problem that is fixed by a newer version, so I wanted to bump this to save someone else the same pain.