### PR TITLE
Add proxy_set_header Host Nginx's example

### DIFF
--- a/content/install/server/nginx.md
+++ b/content/install/server/nginx.md
@@ -43,6 +43,7 @@ server {
     location / {
 +       proxy_set_header X-Forwarded-For $remote_addr;
 +       proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $http_host;
 
         proxy_pass http://127.0.0.1:8000;
         proxy_redirect off;


### PR DESCRIPTION
I copied and pasted the above example which was not passing the  Host header to drone and that caused the redirect_uri to be the internal one.