### PR TITLE
Clarifying branch conditions

### DIFF
--- a/content/usage/config/step-conditions.md
+++ b/content/usage/config/step-conditions.md
@@ -22,6 +22,13 @@ pipeline:
 +     branch: master
 ```
 
+{{% alert info %}}
+Please note that during Pull Request builds there are two branches at play: the source branch where the new code is implemented, and the target branch where the code will be merged to. Drone considers the target branch.
+<br/>
+<br/>
+Thus the above example will build on master and every Pull Request that is opened against master. Look at event based conditions bellow to finetune this behavior.
+{{% /alert %}}
+
 # Branches
 
 Execute a step if the branch is `master` or `develop`:

--- a/content/usage/config/step-conditions.md
+++ b/content/usage/config/step-conditions.md
@@ -23,10 +23,7 @@ pipeline:
 ```
 
 {{% alert info %}}
-Please note that during Pull Request builds there are two branches at play: the source branch where the new code is implemented, and the target branch where the code will be merged to. Drone considers the target branch.
-<br/>
-<br/>
-Thus the above example will build on master and every Pull Request that is opened against master. Look at event based conditions bellow to finetune this behavior.
+The step now triggers on master, but also if the target branch of a pull request is `master`. Add an event condition to limit it further to pushes on master only.
 {{% /alert %}}
 
 # Branches


### PR DESCRIPTION
The clean syntax of branch conditions is a bit misleading. 

One would expect the 
```
  when:
     branch: master
```

snippet to be sufficient in limiting builds to the master branch only.

However the step still triggers for PRs opened against master. Which is counter intuitive, although technically correct.

This PR highlights this issue and suggests a mitigation.