### PR TITLE
Add hint about running matrix builds with drone exec

### DIFF
--- a/content/cli/misc/drone_exec.md
+++ b/content/cli/misc/drone_exec.md
@@ -20,3 +20,9 @@ If your pipeline uses secrets, these can be injected locally simply by passing e
 ```text
 $ MY_SECRET=mybigsecret drone exec
 ```
+
+Running a full matrix build is not supported at this time, however you can execute a single matrix axis by passing environment variables to the `drone exec` command:
+
+```text
+$ GO_VERSION=1.4 drone exec
+```


### PR DESCRIPTION
As described in https://github.com/drone/drone-cli/issues/49 it is not possible right now to run full matrix builds locally. To run a build users need to expose the variables to the drone command.