### PR TITLE
Add submodule_override

### DIFF
--- a/content/usage/concepts/cloning.md
+++ b/content/usage/concepts/cloning.md
@@ -60,3 +60,14 @@ To use the credentials that cloned the repository to clone it's submodules, upda
 -	url = git@github.com:octocat/my-module.git
 +	url = https://github.com/octocat/my-module.git
 ```
+
+To use the ssh git url in `.gitmodules` for users cloning with ssh, and also use the https url in drone, add `submodule_override`:
+
+```diff
+pipeline:
+  clone:
+    image: plugins/git
+    recursive: true
++   submodule_override:
++     my-module: https://github.com/octocat/my-module.git
+```


### PR DESCRIPTION
Stubbled upon this feature when trying to handle allowing folks to clone recursively using ssh, but also allow drone to use https: https://github.com/drone/drone/issues/1092#issuecomment-251525824

Updating the readme to reflect this - as I found it super helpful!