### PR TITLE
fix docs wrt json payload when creating/updating secrets

### DIFF
--- a/content/api/secret/secret_create.md
+++ b/content/api/secret/secret_create.md
@@ -20,9 +20,9 @@ Example Request Body:
 
 ```json
 {
-  "name": "docker_username",
-  "value": "octocat",
-  "event": [
+  "Name": "docker_username",
+  "Value": "octocat",
+  "Event": [
     "push",
     "tags"
   ]

--- a/content/api/secret/secret_update.md
+++ b/content/api/secret/secret_update.md
@@ -21,8 +21,8 @@ Example Request Body:
 
 ```json
 {
-  "value": "octocat",
-  "event": [
+  "Value": "octocat",
+  "Event": [
     "push",
     "pull_request"
   ]


### PR DESCRIPTION
```python
>>> r = requests.post("%s/api/repos/some-org/a-repo/secrets" % DroneUrl, headers={'Authorization': 'Bearer some-token'}, data={"name": "docker_username", "value": "asdf", "event": ["push", "tag", "pull_request"]})
>>> r
<Response [400]>
>>> r.text
u'Error inserting secret. Invalid Secret Name'
```

Changing name -> Name and value -> Value, etc. fixed it. Docs show the values as lowercase currently which was kind of confusing, dug through the cli code to realize that the api wanted the uppercase version.