### PR TITLE
Fix typo on "mycomopany.com"

### DIFF
--- a/content/install/server/caddy.md
+++ b/content/install/server/caddy.md
@@ -12,7 +12,7 @@ url = "setup-with-caddy"
 This guide provides a brief overview for installing Drone server behind the [Caddy webserver](https://caddyserver.com/). This is an example caddyfile proxy configuration:
 
 ```nohighlight
-drone.mycomopany.com {
+drone.mycompany.com {
     gzip {
         not /stream/
     }
@@ -25,7 +25,7 @@ drone.mycomopany.com {
 You must disable gzip compression for streamed data otherwise the live updates won't be instant:
 
 ```diff
-drone.mycomopany.com {
+drone.mycompany.com {
 +   gzip {
 +       not /stream/
 +   }
@@ -39,7 +39,7 @@ drone.mycomopany.com {
 You must configure the proxy to enable websocket upgrades:
 
 ```diff
-drone.mycomopany.com {
+drone.mycompany.com {
     gzip {
         not /stream/
     }
@@ -53,7 +53,7 @@ drone.mycomopany.com {
 You must configure the proxy to include `X-Forwarded` headers using the `transparent` directive:
 
 ```diff
-drone.mycomopany.com {
+drone.mycompany.com {
     gzip {
         not /stream/
     }


### PR DESCRIPTION
Unless it was deliberate, the url for Drone should be "drone.mycompany.com"