### PR TITLE
Add scope hint to GitLab Registration

### DIFF
--- a/content/install/integrations/gitlab.md
+++ b/content/install/integrations/gitlab.md
@@ -74,4 +74,4 @@ DRONE_GITLAB_PRIVATE_MODE=false
 
 You must register your application with GitLab in order to generate a Client and Secret. Navigate to your account settings and choose Applications from the menu, and click New Application.
 
-Please use `http://drone.mycompany.com/authorize` as the Authorization callback URL. And grant `api` scope to the application.
+Please use `http://drone.mycompany.com/authorize` as the Authorization callback URL. Grant `api` scope to the application.

--- a/content/install/integrations/gitlab.md
+++ b/content/install/integrations/gitlab.md
@@ -74,4 +74,4 @@ DRONE_GITLAB_PRIVATE_MODE=false
 
 You must register your application with GitLab in order to generate a Client and Secret. Navigate to your account settings and choose Applications from the menu, and click New Application.
 
-Please use `http://drone.mycompany.com/authorize` as the Authorization callback URL.
+Please use `http://drone.mycompany.com/authorize` as the Authorization callback URL. And grant `api` scope to the application.


### PR DESCRIPTION
As suggested in https://discourse.drone.io/t/authentication-failure-with-gitlab/539/2, `api` scope needs to be granted to application registered in GitLab.