### PR TITLE
Install Doc.: Change host mount to data volume

### DIFF
--- a/content/install/installation_overview.md
+++ b/content/install/installation_overview.md
@@ -37,7 +37,7 @@ services:
       - 80:8000
       - 9000
     volumes:
-      - /var/lib/drone:/var/lib/drone/
+      - drone-server-data:/var/lib/drone/
     restart: always
     environment:
       - DRONE_OPEN=true
@@ -58,6 +58,10 @@ services:
     environment:
       - DRONE_SERVER=drone-server:9000
       - DRONE_SECRET=${DRONE_SECRET}
+
+volumes:
+  drone-server-data:
+
 ```
 
 Drone does not have any builtin user management. Instead, authentication is done using OAuth and is delegated to one of multiple version control providers, configured using environment variables. The example above demonstrates basic GitHub integration.
@@ -82,7 +86,7 @@ services:
       - DRONE_SECRET=${DRONE_SECRET}
 ```
 
-Drone mounts a volume on the host machine to persist the sqlite database.
+Drone mounts a [data volume](https://docs.docker.com/storage/volumes/#create-and-manage-volumes) named "drone-server-data" to persist the sqlite database.
 
 ```diff
 services:
@@ -92,7 +96,7 @@ services:
       - 80:8000
       - 9000
 +   volumes:
-+     - ./drone:/var/lib/drone/
++     - drone-server-data:/var/lib/drone/
     restart: always
 ```
 

--- a/content/install/installation_overview.md
+++ b/content/install/installation_overview.md
@@ -86,7 +86,7 @@ services:
       - DRONE_SECRET=${DRONE_SECRET}
 ```
 
-Drone mounts a [data volume](https://docs.docker.com/storage/volumes/#create-and-manage-volumes) named "drone-server-data" to persist the sqlite database.
+Drone mounts a [data volume](https://docs.docker.com/storage/volumes/#create-and-manage-volumes) to persist the sqlite database.
 
 ```diff
 services:


### PR DESCRIPTION
Hello dear maintainer team!

The motivation is to make the installation guide portable. It fails when running on Docker4Mac and Docker4Windows in the current state for example.
As a matter of fact, using Docker should remove any host "hard" dependency (yeah we still need host servers but... ;)) .

Providing a "host bind mount" is creating a "hard" requirement: the folder `/var/lib/docker` must exist on the host, which is loosing value of using containers.

Proposal here is to use a named data volume:

- Initial goal of persistence is still achieved, but Docker will manage the path to the host's data directory instead of forcing a specified one:
  * Remote Docker Engine will work
  * Docker4Mac and Docker4Windows also
- The data volume being named, it can still be managed using the `docker volume xxx` commands.

Thanks for your work, time and energy in this project!