### PR TITLE
Fix the documentation for git submodule_override.

### DIFF
--- a/content/usage/concepts/cloning.md
+++ b/content/usage/concepts/cloning.md
@@ -64,10 +64,13 @@ To use the credentials that cloned the repository to clone it's submodules, upda
 To use the ssh git url in `.gitmodules` for users cloning with ssh, and also use the https url in drone, add `submodule_override`:
 
 ```diff
-pipeline:
-  clone:
+clone:
+  git:
     image: plugins/git
     recursive: true
 +   submodule_override:
 +     my-module: https://github.com/octocat/my-module.git
+    
+pipeline:
+  ...
 ```


### PR DESCRIPTION
The original document put the "submodule_override" section under the wrong parent node.
It should be at the top level and like other git related commands.
