### PR TITLE
typo

### DIFF
--- a/content/faq/secrets_not_working.md
+++ b/content/faq/secrets_not_working.md
@@ -89,6 +89,6 @@ If you continue to experience issues you can engage the community for support. P
 
 * the full yaml configuration file
 * the relevant logs from your build
-* the results of `drone secrets ls <repo>`
+* the results of `drone secret ls <repo>`
 * the results of `drone repo info <repo>`
 * the results of `drone build info <repo> <build_number>`


### PR DESCRIPTION
`drone secrets ls` should be `drone secret ls`.