### PR TITLE
Bump version to 0.8.6

### DIFF
--- a/content/cli/cli_overview.md
+++ b/content/cli/cli_overview.md
@@ -17,11 +17,11 @@ Download and install the raw binaries by platform:
 
 Platform    | Download
 ------------|---------
-Linux x64   | [tarball](https://github.com/drone/drone-cli/releases/download/v0.8.5/drone_linux_amd64.tar.gz)
-Linux arm64 | [tarball](https://github.com/drone/drone-cli/releases/download/v0.8.5/drone_linux_arm64.tar.gz)
-Linux arm   | [tarball](https://github.com/drone/drone-cli/releases/download/v0.8.5/drone_linux_arm.tar.gz)
-Windows x64 | [tarball](https://github.com/drone/drone-cli/releases/download/v0.8.5/drone_windows_amd64.tar.gz)
-Darwin x64  | [tarball](https://github.com/drone/drone-cli/releases/download/v0.8.5/drone_darwin_amd64.tar.gz)
+Linux x64   | [tarball](https://github.com/drone/drone-cli/releases/download/v0.8.6/drone_linux_amd64.tar.gz)
+Linux arm64 | [tarball](https://github.com/drone/drone-cli/releases/download/v0.8.6/drone_linux_arm64.tar.gz)
+Linux arm   | [tarball](https://github.com/drone/drone-cli/releases/download/v0.8.6/drone_linux_arm.tar.gz)
+Windows x64 | [tarball](https://github.com/drone/drone-cli/releases/download/v0.8.6/drone_windows_amd64.tar.gz)
+Darwin x64  | [tarball](https://github.com/drone/drone-cli/releases/download/v0.8.6/drone_darwin_amd64.tar.gz)
 
 # Install on Windows
 
@@ -36,7 +36,7 @@ scoop install drone
 Download and install on Linux:
 
 ```nohighlight
-curl -L https://github.com/drone/drone-cli/releases/download/v0.8.5/drone_linux_amd64.tar.gz | tar zx
+curl -L https://github.com/drone/drone-cli/releases/download/v0.8.6/drone_linux_amd64.tar.gz | tar zx
 sudo install -t /usr/local/bin drone
 ```
 
@@ -45,7 +45,7 @@ sudo install -t /usr/local/bin drone
 Download and install on OSX:
 
 ```nohighlight
-curl -L https://github.com/drone/drone-cli/releases/download/v0.8.5/drone_darwin_amd64.tar.gz | tar zx
+curl -L https://github.com/drone/drone-cli/releases/download/v0.8.6/drone_darwin_amd64.tar.gz | tar zx
 sudo cp drone /usr/local/bin
 ```
 

--- a/content/cli/cli_overview.zh.md
+++ b/content/cli/cli_overview.zh.md
@@ -35,10 +35,10 @@ Darwin x64  | [tarball](https://github.com/drone/drone-cli/releases/)
 
 <!--Download and install on Linux:-->
 
-访问 https://github.com/drone/drone-cli/releases/ 了解最新版本号，可替换 v0.8.3 为最新版本。
+访问 https://github.com/drone/drone-cli/releases/ 了解最新版本号，可替换 v0.8.6 为最新版本。
 
 ```nohighlight
-curl -L https://github.com/drone/drone-cli/releases/download/v0.8.3/drone_linux_amd64.tar.gz | tar zx
+curl -L https://github.com/drone/drone-cli/releases/download/v0.8.6/drone_linux_amd64.tar.gz | tar zx
 sudo install -t /usr/local/bin drone
 ```
 
@@ -48,10 +48,10 @@ sudo install -t /usr/local/bin drone
 
 <!--Download and install on OSX:-->
 
-访问 https://github.com/drone/drone-cli/releases/ 了解最新版本号，可替换 v0.8.3 为最新版本。
+访问 https://github.com/drone/drone-cli/releases/ 了解最新版本号，可替换 v0.8.6 为最新版本。
 
 ```nohighlight
-curl -L https://github.com/drone/drone-cli/releases/download/v0.8.3/drone_darwin_amd64.tar.gz | tar zx
+curl -L https://github.com/drone/drone-cli/releases/download/v0.8.6/drone_darwin_amd64.tar.gz | tar zx
 sudo cp drone /usr/local/bin
 ```
 


### PR DESCRIPTION
If you cut-paste the install commands, then you end up with a slightly old version.
It would be nice to keep these up-to-date.