### PR TITLE
Add more suitable go workspace example

### DIFF
--- a/content/usage/concepts/workspace.md
+++ b/content/usage/concepts/workspace.md
@@ -19,8 +19,8 @@ The workspace can be customized using the workspace block in the Yaml file:
 
 ```diff
 +workspace:
-+  base: /go
-+  path: src/github.com/octocat/hello-world
++  base: /go/src
++  path: github.com/octocat/hello-world
 
 pipeline:
   build:
@@ -34,8 +34,8 @@ The base attribute defines a shared base volume available to all pipeline steps.
 
 ```diff
 workspace:
-+ base: /go
-  path: src/github.com/octocat/hello-world
++ base: /go/src
+  path: github.com/octocat/hello-world
 
 pipeline:
   deps:
@@ -54,16 +54,16 @@ This would be equivalent to the following docker commands:
 ```
 docker volume create my-named-volume
 
-docker run --volume=my-named-volume:/go golang:latest
-docker run --volume=my-named-volume:/go node:latest
+docker run --volume=my-named-volume:/go/src golang:latest
+docker run --volume=my-named-volume:/go/src node:latest
 ```
 
 The path attribute defines the working directory of your build. This is where your code is cloned and will be the default working directory of every step in your build process. The path must be relative and is combined with your base path.
 
 ```diff
 workspace:
-  base: /go
-+ path: src/github.com/octocat/hello-world
+  base: /go/src
++ path: github.com/octocat/hello-world
 ```
 
 ```text


### PR DESCRIPTION
The default go workspace example uses `/go` as the mount point, which also wipes out `/go/bin`, and `/go/pkg`, which usually comes in the base image for CI builds. Anything that would be preinstalled with `go get -u ...` would be lost (static analysis tools, code generators, dep,...). The proposed change just adds a more specific workspace base, to avoid this issue outright.