### PR TITLE
Remove tag warning mentioning "branches" on event conditions

### DIFF
--- a/content/pipeline/conditions.md
+++ b/content/pipeline/conditions.md
@@ -92,10 +92,6 @@ when:
 
 The event condition limits step execution based on the drone event type. This can be helpful when you want to limit steps based on push, pull request, tag and more.
 
-<div class="alert alert-warn">
-Note that you cannot use branch conditions with tag events. A tag is not associated with the source branch from which it was created.
-</div>
-
 {{< highlight yaml "linenos=table,linenostart=11" >}}
 when:
   event:


### PR DESCRIPTION
When reading the documentation about event conditions I found what I think is a misplaced warning about tags mentioning "branch conditions" in section https://docs.drone.io/pipeline/conditions/#by-event

I wanted to open this PR to propose removing it in case it is unintentional.

Please feel free to reject this PR in case the removed phrasing is actually intended.