### PR TITLE
Provide direct link to Github OAuth registration form

### DIFF
--- a/content/server/provider/github.md
+++ b/content/server/provider/github.md
@@ -34,7 +34,7 @@ This article explains how to install the Drone server for GitHub. The server is 
 
 ## Create an OAuth Application
 
-Create a [GitHub OAuth application](https://github.com/settings/applications/new). The Consumer Key and Consumer Secret are used to authorize access to GitHub resources.
+[Create a GitHub OAuth application](https://docs.github.com/en/developers/apps/creating-an-oauth-app). The Consumer Key and Consumer Secret are used to authorize access to GitHub resources.
 
 <div class="alert alert-warn">
 The authorization callback URL must match the below format and path, and must use your exact server scheme and host.

--- a/content/server/provider/github.md
+++ b/content/server/provider/github.md
@@ -34,7 +34,7 @@ This article explains how to install the Drone server for GitHub. The server is 
 
 ## Create an OAuth Application
 
-Create a GitHub OAuth application. The Consumer Key and Consumer Secret are used to authorize access to GitHub resources.
+Create a [GitHub OAuth application](https://github.com/settings/applications/new). The Consumer Key and Consumer Secret are used to authorize access to GitHub resources.
 
 <div class="alert alert-warn">
 The authorization callback URL must match the below format and path, and must use your exact server scheme and host.


### PR DESCRIPTION
This may save potential users some clicks and make setup faster by avoiding them to search for the right button in Githubs ever-growing UI.

The inserted link (https://github.com/settings/applications/new) is the same for all logged-in Github users so it should be usable in a public-facing documentation like this.