### PR TITLE
Link about configuration extensions leads to conversion

### DIFF
--- a/content/extensions/overview.md
+++ b/content/extensions/overview.md
@@ -13,7 +13,7 @@ Here is a list of extension types:
 
 {{< link "/extensions/admission.md" "Admission Extensions" >}}
 {{< link "/extensions/conversion.md" "Conversion Extensions" >}}
-{{< link "/extensions/conversion.md" "Configuration Extensions" >}}
+{{< link "/extensions/configuration.md" "Configuration Extensions" >}}
 {{< link "/extensions/environment" "Environment Extensions" >}}
 {{< link "/extensions/registry" "Registry Extensions" >}}
 {{< link "/extensions/secret.md" "Secret Extensions" >}}


### PR DESCRIPTION
When looking at https://docs.drone.io/extensions/overview/ I tried to follow the link to "Configuration Extensions" but arrived at https://docs.drone.io/extensions/conversion/ which is the wrong target.