### PR TITLE
Fix highlight line numbers

### DIFF
--- a/content/pipeline/docker/syntax/steps.md
+++ b/content/pipeline/docker/syntax/steps.md
@@ -72,7 +72,7 @@ The container exit code is used to determine whether the step is passing or fail
 
 The environment section provides the ability to define environment variables scoped to individual pipeline steps.
 
-{{< highlight text "linenos=table,hl_lines=3-5,linenostart=5" >}}
+{{< highlight text "linenos=table,hl_lines=4-6,linenostart=5" >}}
 steps:
 - name: backend
   image: golang


### PR DESCRIPTION
On https://docs.drone.io/pipeline/docker/syntax/steps/#environment the line numbers to not match up the the YAML lines specifying the `environment:` config due to off-by-one error, see problem picture: 
![Auswahl_1010](https://user-images.githubusercontent.com/800933/93249152-24539f00-f791-11ea-925d-befc4e812afb.png)
