### PR TITLE
Update - was duplicate of drone-repo-namespace.md

### DIFF
--- a/content/pipeline/environment/reference/drone-repo-owner.md
+++ b/content/pipeline/environment/reference/drone-repo-owner.md
@@ -4,7 +4,7 @@ title: DRONE_REPO_OWNER
 author: bradrydzewski
 ---
 
-Provides the repository namespace for the current running build. The namespace is an alias for the source control management account that owns the repository.
+Provides the repository owner for the current running build. The owner is the source control management account that owns the repository.
 
 ```
 DRONE_REPO_OWNER=octocat


### PR DESCRIPTION
The body of this page still referred to the 'repo namespace'. Please inform if this edit is correct. Without further investigation I have assumed the DRONE_REPO_OWNER is simply the owner of the repo, without aliases in the same way as DRONE_REPO_NAMESPACE