### PR TITLE
Add example for usage of ServiceAccounts in k8s Pipelines

### DIFF
--- a/content/pipeline/kubernetes/overview.md
+++ b/content/pipeline/kubernetes/overview.md
@@ -59,3 +59,12 @@ steps:
   - go build
   - go test
 {{< / highlight >}}
+
+To bind a non-default service account to a pipeline to allow for more fine grained access to resouces.
+
+{{< highlight text "linenos=table" >}}
+---
+kind: pipeline
+type: kubernetes
+service_account_name: builder
+{{< / highlight >}}


### PR DESCRIPTION
There are no existing up-to-date docs on how to set a non-default
`ServiceAccountName` to a pipeline. The following documents and
discussions were original examples and none of them correctly bind the
ServiceAccountName to the pod.

https://docs.drone.io/runner/kubernetes/configuration/reference/drone-service-account-default/
https://discourse.drone.io/t/drone-runner-kube-default-global-serviceaccountname-nodeselector-and-tolerations-for-pipeline-pods/6684