### PR TITLE
Fix cron include & exclude examples

### DIFF
--- a/content/pipeline/triggers.md
+++ b/content/pipeline/triggers.md
@@ -323,7 +323,7 @@ Example include syntax:
 trigger:
   event:
   - cron
-  target:
+  cron:
     include:
     - weekly
     - nightly
@@ -335,7 +335,7 @@ Example exclude syntax:
 trigger:
   event:
   - cron
-  target:
+  cron:
     exclude:
     - nightly
 {{< / highlight >}}


### PR DESCRIPTION
Instead of `target` it should be `cron`