### PR TITLE
Fix DRONE_UI_REALM Examples

### DIFF
--- a/content/runner/digitalocean/configuration/reference/drone-ui-realm.md
+++ b/content/runner/digitalocean/configuration/reference/drone-ui-realm.md
@@ -8,5 +8,5 @@ weight: 1
 Optional string value. Sets the basic authentication realm used to authenticate and access the web dashboard.
 
 ```
-DRONE_UI_PASSWORD=DroneRealm
+DRONE_UI_REALM=DroneRealm
 ```

--- a/content/runner/docker/configuration/reference/drone-ui-realm.md
+++ b/content/runner/docker/configuration/reference/drone-ui-realm.md
@@ -8,5 +8,5 @@ weight: 1
 Optional string value. Sets the basic authentication realm used to authenticate and access the web dashboard.
 
 ```
-DRONE_UI_PASSWORD=DroneRealm
+DRONE_UI_REALM=DroneRealm
 ```

--- a/content/runner/exec/configuration/reference/drone-ui-realm.md
+++ b/content/runner/exec/configuration/reference/drone-ui-realm.md
@@ -8,5 +8,5 @@ weight: 1
 Optional string value. Sets the basic authentication realm used to authenticate and access the web dashboard.
 
 ```
-DRONE_UI_PASSWORD=DroneRealm
+DRONE_UI_REALM=DroneRealm
 ```

--- a/content/runner/kubernetes/configuration/reference/drone-ui-realm.md
+++ b/content/runner/kubernetes/configuration/reference/drone-ui-realm.md
@@ -8,5 +8,5 @@ weight: 1
 Optional string value. Sets the basic authentication realm used to authenticate and access the web dashboard.
 
 ```
-DRONE_UI_PASSWORD=DroneRealm
+DRONE_UI_REALM=DroneRealm
 ```

--- a/content/runner/macstadium/configuration/reference/drone-ui-realm.md
+++ b/content/runner/macstadium/configuration/reference/drone-ui-realm.md
@@ -8,5 +8,5 @@ weight: 1
 Optional string value. Sets the basic authentication realm used to authenticate and access the web dashboard.
 
 ```
-DRONE_UI_PASSWORD=DroneRealm
+DRONE_UI_REALM=DroneRealm
 ```

--- a/content/runner/ssh/configuration/reference/drone-ui-realm.md
+++ b/content/runner/ssh/configuration/reference/drone-ui-realm.md
@@ -8,5 +8,5 @@ weight: 1
 Optional string value. Sets the basic authentication realm used to authenticate and access the web dashboard.
 
 ```
-DRONE_UI_PASSWORD=DroneRealm
+DRONE_UI_REALM=DroneRealm
 ```


### PR DESCRIPTION
All `DRONE_UI_REALM` examples stated `DRONE_UI_PASSWORD` instead.