### PR TITLE
Add project visibility documentation

### DIFF
--- a/content/setting/_index.md
+++ b/content/setting/_index.md
@@ -1,0 +1,14 @@
+---
+date: 2000-01-01T00:00:00+00:00
+title: Settings
+weight: 140
+toc: true
+aliases:
+- /configure/settings
+- /user-guide/settings
+---
+
+Here are the articles in this section:
+
+{{< cards >}}
+

--- a/content/setting/visibility.md
+++ b/content/setting/visibility.md
@@ -1,0 +1,26 @@
+---
+date: 2000-01-01T00:00:00+00:00
+title: Visibility
+weight: 100
+disable_toc: true
+aliases:
+- /configure/settings/visibility/
+- /user-guide/settings/visibility/
+description: |
+  Provides the repository visibility level.
+---
+
+You can use the visibility feature to set the repository visibility level, for example, _set visibility to private_.
+
+# Public
+
+The project will be visible by anyone.
+
+# Private
+
+The project will be visible by anyone with access.
+
+# Internal
+
+The project will be visible by any authenticated user.
+

--- a/layouts/partials/sidebar-home.html
+++ b/layouts/partials/sidebar-home.html
@@ -14,6 +14,7 @@
             <li class="category separator">Usage</li>
             <li class="sidebar-item"><a href="/quickstart">Quickstart</a></li>
             <li class="sidebar-item"><a href="/pipeline/overview">Pipelines</a></li>
+            <li class="sidebar-item"><a href="/setting/">Settings</a></li>
             <li class="sidebar-item"><a href="/secret/">Secrets</a></li>
             <li class="sidebar-item"><a href="/signature/">Signatures</a></li>
             <!-- <li class="sidebar-item"><a href="/coverage/">Coverage</a></li>  -->


### PR DESCRIPTION
Spent too much time trying to figure this option out, so I am adding it to the documentation.

It felt logical here to add a "Settings" section as its not directly related to pipelines but more to a whole project settings.

<img width="252" alt="image" src="https://user-images.githubusercontent.com/23703318/108248415-1a750400-7154-11eb-8574-21b2fb6aabb9.png">
<img width="912" alt="image" src="https://user-images.githubusercontent.com/23703318/108248277-ef8ab000-7153-11eb-84ae-7b610809f423.png">
<img width="924" alt="image" src="https://user-images.githubusercontent.com/23703318/108248854-a424d180-7154-11eb-870e-8f24f313bce3.png">

Source: https://github.com/drone/drone/issues/2042