### PR TITLE
refresh git clone recommended tweaks

### DIFF
--- a/content/pipeline/docker/syntax/cloning/_index.md
+++ b/content/pipeline/docker/syntax/cloning/_index.md
@@ -44,7 +44,7 @@ name: default
 
 steps:
 - name: fetch
-  image: alpine/git
+  image: plugins/git
   commands:
   - git fetch --tags
 
@@ -67,7 +67,7 @@ name: default
 
 steps:
 - name: submodules
-  image: alpine/git
+  image: plugins/git
   commands:
   - git submodule update --recursive --remote
 
@@ -92,7 +92,7 @@ clone:
 
 steps:
 - name: clone
-  image: alpine/git
+  image: plugins/git
   commands:
   - git clone https://github.com/octocat/hello-world.git .
   - git checkout $DRONE_COMMIT

--- a/content/pipeline/docker/syntax/cloning/_index.md
+++ b/content/pipeline/docker/syntax/cloning/_index.md
@@ -58,18 +58,19 @@ steps:
 
 # The `--recursive` flag
 
-The default clone behavior does not use the `--recursive` flag and does not fetch submodules. If you would like to fetch submodules you should handle this as a step in your pipeline. For example:
+The default clone behavior does not use the `--recursive` flag and does not fetch submodules. If you would like to fetch submodules you should handle this by using a personalised `clone` step. For example:
 
 {{< highlight text "linenos=table,hl_lines=6-9" >}}
 kind: pipeline
 type: docker
 name: default
+clone:
+  disable: true
 
 steps:
-- name: submodules
+- name: clone
   image: plugins/git
-  commands:
-  - git submodule update --recursive --remote
+  recursive: true
 
 - name: build
   image: golang


### PR DESCRIPTION
`alpine/git` is not usable in drone-runner-docker:1, but using `plugins/git` the rest of the cloning syntax page is apparently still valid.