### PR TITLE
Fix mixed environment variables in DRONE_LIMIT_REPOS docs

### DIFF
--- a/content/runner/digitalocean/configuration/reference/drone-limit-repos.md
+++ b/content/runner/digitalocean/configuration/reference/drone-limit-repos.md
@@ -9,5 +9,5 @@ draft: true
 Optional comma-separated string value. Configures the runner to only process matching repositories. This provides an extra layer of security and can stop untrusted repositories from executing pipelines with this runner.
 
 ```
-DRONE_LIMIT_EVENTS=octocat/hello-world,spaceghost/*
+DRONE_LIMIT_REPOS=octocat/hello-world,spaceghost/*
 ```

--- a/content/runner/docker/configuration/reference/drone-limit-repos.md
+++ b/content/runner/docker/configuration/reference/drone-limit-repos.md
@@ -8,5 +8,5 @@ weight: 1
 Optional comma-separated string value. Configures the runner to only process matching repositories. This provides an extra layer of security and can stop untrusted repositories from executing pipelines with this runner.
 
 ```
-DRONE_LIMIT_EVENTS=octocat/hello-world,spaceghost/*
+DRONE_LIMIT_REPOS=octocat/hello-world,spaceghost/*
 ```


### PR DESCRIPTION
A first pass for https://github.com/drone-runners/drone-runner-docker/pull/19. If that is merged, I'll be happy to extend this docs in a follow-up PR with additional examples.