### PR TITLE
fix(kube-runner): typo on repositories policy match

### DIFF
--- a/content/runner/kubernetes/configuration/policies.md
+++ b/content/runner/kubernetes/configuration/policies.md
@@ -17,7 +17,7 @@ kind: policy
 name: octocat
 
 match:
-  repos:
+  repo:
   - "octocat/*"
   - "octocat/hello-world"
 
@@ -55,7 +55,7 @@ kind: policy
 name: octocat
 
 match:
-  repos:
+  repo:
   - "octocat/*"
   - "octocat/hello-world"
 
@@ -80,7 +80,7 @@ kind: policy
 name: octocat
 
 match:
-  repos:
+  repo:
   - "octocat/*"
   - "octocat/hello-world"
 
@@ -160,7 +160,7 @@ metadata:
   service_account: drone
 
   match:
-    repos:
+    repo:
     - "octocat/*"
     - "octocat/hello-world"
   ```
@@ -175,7 +175,7 @@ metadata:
     namespace: default
 
   match:
-    repos:
+    repo:
     - "octocat/*"
     - "octocat/hello-world"
   ```


### PR DESCRIPTION
We were struggling to make our policies work here, no matter how we set our rules, the first policy was always matched. So we checked the manifest files and noticed that the correct `yaml` key is **repo** and not **repos**.After changing this everything worked like a charm.
