### PR TITLE
Fix: Updated variable names in Extensions section

### DIFF
--- a/content/extensions/environment.md
+++ b/content/extensions/environment.md
@@ -19,8 +19,8 @@ You can register an extension with your runners by providing the following confi
 * `DRONE_ENV_PLUGIN_ENDPOINT`
   : Provides the endpoint used to make http requests to the extension.
 
-* `DRONE_ENV_PLUGIN_TOKEN`
-  : Provides the token used to authenticate http requests to the extension. This token is shared between the server and extension.
+* `DRONE_ENV_PLUGIN_SECRET`
+  : Provides the secret used to authenticate http requests to the extension. This token is shared between the server and extension.
 
 # How it Works
 

--- a/content/extensions/environment.md
+++ b/content/extensions/environment.md
@@ -20,7 +20,7 @@ You can register an extension with your runners by providing the following confi
   : Provides the endpoint used to make http requests to the extension.
 
 * `DRONE_ENV_PLUGIN_SECRET`
-  : Provides the secret used to authenticate http requests to the extension. This token is shared between the server and extension.
+  : Provides the token used to authenticate http requests to the extension. This token is shared between the server and extension.
 
 # How it Works
 

--- a/content/extensions/registry.md
+++ b/content/extensions/registry.md
@@ -16,8 +16,8 @@ You can register an extension with your runners by providing the following confi
 * `DRONE_REGISTRY_PLUGIN_ENDPOINT`
   : Provides the endpoint used to make http requests to a registry extension.
 
-* `DRONE_REGISTRY_PLUGIN_TOKEN`
-  : Provides the token used to authenticate http requests to the extension. This token is shared between the server and extension.
+* `DRONE_REGISTRY_PLUGIN_SECRET`
+  : Provides the secret used to authenticate http requests to the extension. This secret is shared between the server and extension.
 
 # How it Works
 

--- a/content/extensions/registry.md
+++ b/content/extensions/registry.md
@@ -17,7 +17,7 @@ You can register an extension with your runners by providing the following confi
   : Provides the endpoint used to make http requests to a registry extension.
 
 * `DRONE_REGISTRY_PLUGIN_SECRET`
-  : Provides the secret used to authenticate http requests to the extension. This secret is shared between the server and extension.
+  : Provides the secret used to authenticate http requests to the extension. This token is shared between the server and extension.
 
 # How it Works
 

--- a/content/extensions/registry.md
+++ b/content/extensions/registry.md
@@ -17,7 +17,7 @@ You can register an extension with your runners by providing the following confi
   : Provides the endpoint used to make http requests to a registry extension.
 
 * `DRONE_REGISTRY_PLUGIN_SECRET`
-  : Provides the secret used to authenticate http requests to the extension. This token is shared between the server and extension.
+  : Provides the token used to authenticate http requests to the extension. This token is shared between the server and extension.
 
 # How it Works
 

--- a/content/extensions/secret.md
+++ b/content/extensions/secret.md
@@ -26,7 +26,7 @@ You can register a secret extension with your runners by providing the following
   : Provides the endpoint used to make http requests to a secret extension.
 
 * `DRONE_SECRET_PLUGIN_SECRET`
-  : Provides the secret used to authenticate http requests to the extension. This token is shared between the server and extension.
+  : Provides the token used to authenticate http requests to the extension. This token is shared between the server and extension.
 
 <div class="alert">
 Secret extensions are registered with runners as opposed to the central server. This design is intentional. For example, runners in different regions or data centers may have access to different secrets.

--- a/content/extensions/secret.md
+++ b/content/extensions/secret.md
@@ -25,7 +25,7 @@ You can register a secret extension with your runners by providing the following
 * `DRONE_SECRET_PLUGIN_ENDPOINT`
   : Provides the endpoint used to make http requests to a secret extension.
 
-* `DRONE_SECRET_PLUGIN_TOKEN`
+* `DRONE_SECRET_PLUGIN_SECRET`
   : Provides the token used to authenticate http requests to the extension. This token is shared between the server and extension.
 
 <div class="alert">

--- a/content/extensions/secret.md
+++ b/content/extensions/secret.md
@@ -26,7 +26,7 @@ You can register a secret extension with your runners by providing the following
   : Provides the endpoint used to make http requests to a secret extension.
 
 * `DRONE_SECRET_PLUGIN_SECRET`
-  : Provides the token used to authenticate http requests to the extension. This token is shared between the server and extension.
+  : Provides the secret used to authenticate http requests to the extension. This token is shared between the server and extension.
 
 <div class="alert">
 Secret extensions are registered with runners as opposed to the central server. This design is intentional. For example, runners in different regions or data centers may have access to different secrets.


### PR DESCRIPTION
Several variable named were titled `DRONE_{EXTENSION_TYPE}_PLUGIN_TOKEN`, when they should be called `DRONE_{EXTENSION_TYPE}_PLUGIN_SECRET`.