### PR TITLE
Document DRONE_RUNNER_SYMLINKS environment variable

### DIFF
--- a/content/runner/exec/configuration/reference/drone-runner-symlinks.md
+++ b/content/runner/exec/configuration/reference/drone-runner-symlinks.md
@@ -1,0 +1,13 @@
+---
+date: 2000-01-01T00:00:00+00:00
+title: DRONE_RUNNER_SYMLINKS
+author: lucarge
+weight: 1
+---
+
+Optional string value. Generate symlinks. This may be required if you're building an iOS app via XCode.
+
+```
+DRONE_RUNNER_SYMLINKS=/Users/xxxx/Library:/home/drone/Library
+```
+


### PR DESCRIPTION
Following the discussion that happened in [this discourse thread](https://discourse.drone.io/t/exec-runner-support-for-xcode-projects/5895/15), this pull request documents the newly added `DRONE_RUNNER_SYMLINKS` environment variable. 