### PR TITLE
(main) Replaced shorthand commands, fixed indentation and applied formatting to nomad installation Doc.

### DIFF
--- a/content/runner/nomad/installation.md
+++ b/content/runner/nomad/installation.md
@@ -48,7 +48,7 @@ The Nomad runner is configured using environment variables. This article referen
 
 The below command creates a container and starts the Docker runner. _Remember to replace the environment variables below with your Drone server details._
 
-```
+
 {{< highlight handlebars "linenos=table" >}}
 docker run --detach \
   --volume=/var/run/docker.sock:/var/run/docker.sock \
@@ -61,7 +61,7 @@ docker run --detach \
   --name=runner \
   drone/drone-runner-nomad:latest
 {{< / highlight >}}
-```
+
 
 # Verification
 


### PR DESCRIPTION
### Issue
This is another PR towards ensuring uniformity in the code examples as stated in #484.

### Procedure
I replaced shorthand commands, fixed indentation and applied formatting to nomad installation Doc.
#### Reference 
[Docker Run Documentation](https://docs.docker.com/engine/reference/commandline/run/)

### Screenshots
![Screenshot from 2021-10-07 22-20-05](https://user-images.githubusercontent.com/25867172/136463861-047be0c4-98ce-45fd-8106-7067d62b1f3c.png)
