### PR TITLE
(maint) Replaced shorthand options in command

### DIFF
--- a/content/runner/docker/installation/linux.md
+++ b/content/runner/docker/installation/linux.md
@@ -46,7 +46,6 @@ The Docker runner is configured using environment variables. This article refere
 
 The below command creates a container and starts the Docker runner. _Remember to replace the environment variables below with your Drone server details._
 
-```
 {{< highlight handlebars "linenos=table" >}}
 docker run --detach \
   --volume=/var/run/docker.sock:/var/run/docker.sock \
@@ -60,7 +59,6 @@ docker run --detach \
   --name=runner \
   drone/drone-runner-docker:1
 {{< / highlight >}}
-```
 
 # Verification
 

--- a/content/runner/docker/installation/windows.md
+++ b/content/runner/docker/installation/windows.md
@@ -48,7 +48,6 @@ The Docker runner is configured using environment variables. This article refere
 
 The below command creates a container and starts the Docker runner. _Remember to replace the environment variables below with your Drone server details._
 
-```
 {{< highlight handlebars "linenos=table" >}}
 docker run --detach \
   --volume=//./pipe/docker_engine://./pipe/docker_engine \
@@ -62,7 +61,6 @@ docker run --detach \
   --name=runner \
   drone/drone-runner-docker:1
 {{< / highlight >}}
-```
 
 # Verification
 


### PR DESCRIPTION
### Issue
This is a PR meant to fix #484. ***This PR contains a fix for the redundant codeblock backticks as stated in #485***

### Procedure
I simply replaced the shorthand options with their full equivalents. 

#### Reference 
[Docker Run Documentation](https://docs.docker.com/engine/reference/commandline/run/)

