### PR TITLE
(maint) Update highlighting for consistency on installation instructions for Github

### DIFF
--- a/content/server/provider/github.md
+++ b/content/server/provider/github.md
@@ -87,14 +87,14 @@ The Drone server is configured using environment variables. This article referen
 
 The server container can be started with the below command. The container is configured through environment variables. For a full list of configuration parameters, please see the configuration reference.
 
-{{< highlight handlebars "linenos=table" >}}
+{{< highlight bash "linenos=table,hl_lines=3-7" >}}
 docker run \
   --volume=/var/lib/drone:/data \
-  --env=DRONE_GITHUB_CLIENT_ID={{DRONE_GITHUB_CLIENT_ID}} \
-  --env=DRONE_GITHUB_CLIENT_SECRET={{DRONE_GITHUB_CLIENT_SECRET}} \
-  --env=DRONE_RPC_SECRET={{DRONE_RPC_SECRET}} \
-  --env=DRONE_SERVER_HOST={{DRONE_SERVER_HOST}} \
-  --env=DRONE_SERVER_PROTO={{DRONE_SERVER_PROTO}} \
+  --env=DRONE_GITHUB_CLIENT_ID=your-id \
+  --env=DRONE_GITHUB_CLIENT_SECRET=super-duper-secret \
+  --env=DRONE_RPC_SECRET=super-duper-secret \
+  --env=DRONE_SERVER_HOST=drone.company.com \
+  --env=DRONE_SERVER_PROTO=https \
   --publish=80:80 \
   --publish=443:443 \
   --restart=always \


### PR DESCRIPTION
Close #497 

Updating the highlighting and examples for consistency with [https://docs.drone.io/runner/docker/installation/linux/](https://docs.drone.io/runner/docker/installation/linux/)
![2021-10-23 16 27 17 localhost 1292041bdb35](https://user-images.githubusercontent.com/26224873/138562548-cd683a31-a29a-4227-8004-6b85c60f69b6.png)
:
