### PR TITLE
(maint) Update Readme to clarify that on Windows the extended version of Hugo must be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the source for [docs.drone.io](http://docs.drone.io).
 To generate the documentation you will need to download and install the [hugo](https://gohugo.io/overview/installing/) static website engine.
-If you are following the Windows installation instructions you will need the extended version.
+If you are following the [Windows installation instructions](https://gohugo.io/getting-started/installing/#chocolatey-windows) you will need the extended version.
 
 Generate the documentation:
 


### PR DESCRIPTION
Close #499 

Add line to Readme to clarify that the extended version of Hugo must be installed to generate the docs on Windows.