### PR TITLE
(maint) added real life examples and highlighting to bash command in Gitea Doc.

### DIFF
--- a/content/server/provider/gitea.md
+++ b/content/server/provider/gitea.md
@@ -82,15 +82,15 @@ The Drone server is configured using environment variables. This article referen
 
 The server container can be started with the below command. The container is configured through environment variables. For a full list of configuration parameters, please see the configuration reference.
 
-{{< highlight handlebars "linenos=table" >}}
+{{< highlight bash "linenos=table,hl_lines=3-8" >}}
 docker run \
   --volume=/var/lib/drone:/data \
-  --env=DRONE_GITEA_SERVER={{DRONE_GITEA_SERVER}} \
-  --env=DRONE_GITEA_CLIENT_ID={{DRONE_GITEA_CLIENT_ID}} \
-  --env=DRONE_GITEA_CLIENT_SECRET={{DRONE_GITEA_CLIENT_SECRET}} \
-  --env=DRONE_RPC_SECRET={{DRONE_RPC_SECRET}} \
-  --env=DRONE_SERVER_HOST={{DRONE_SERVER_HOST}} \
-  --env=DRONE_SERVER_PROTO={{DRONE_SERVER_PROTO}} \
+  --env=DRONE_GITEA_SERVER=https://try.gitea.io \
+  --env=DRONE_GITEA_CLIENT_ID=05136e57d80189bef462 \
+  --env=DRONE_GITEA_CLIENT_SECRET=7c229228a77d2cbddaa61ddc78d45e \
+  --env=DRONE_RPC_SECRET=super-duper-secret \
+  --env=DRONE_SERVER_HOST=drone.company.com \
+  --env=DRONE_SERVER_PROTO=https \
   --publish=80:80 \
   --publish=443:443 \
   --restart=always \


### PR DESCRIPTION
I updated the placeholders in the Gitea docs with real-life examples. I also highlighted the environment variable lines. Here is the screenshot of my fix.

![gitea](https://user-images.githubusercontent.com/25867172/138618309-f00db686-8ba1-4907-8c01-edb3fa28df2e.png)


