### PR TITLE
(maint) added real life examples and highlighting to bash command in Gitlab Doc

### DIFF
--- a/content/server/provider/gitlab.md
+++ b/content/server/provider/gitlab.md
@@ -75,15 +75,15 @@ The Drone server is configured using environment variables. This article referen
 
 The server container can be started with the below command. The container is configured through environment variables. _Remember to replace the placeholder values below with the appropriate values._
 
-{{< highlight handlebars "linenos=table" >}}
+{{< highlight bash "linenos=table,hl_lines=3-8" >}}
 docker run \
   --volume=/var/lib/drone:/data \
   --env=DRONE_GITLAB_SERVER=https://gitlab.com \
-  --env=DRONE_GITLAB_CLIENT_ID={{DRONE_GITLAB_CLIENT_ID}} \
-  --env=DRONE_GITLAB_CLIENT_SECRET={{DRONE_GITLAB_CLIENT_SECRET}} \
-  --env=DRONE_RPC_SECRET={{DRONE_RPC_SECRET}} \
-  --env=DRONE_SERVER_HOST={{DRONE_SERVER_HOST}} \
-  --env=DRONE_SERVER_PROTO={{DRONE_SERVER_PROTO}} \
+  --env=DRONE_GITLAB_CLIENT_ID=05136e57d80189bef462 \
+  --env=DRONE_GITLAB_CLIENT_SECRET=7c229228a77d2cbddaa61ddc78d45e \
+  --env=DRONE_RPC_SECRET=super-duper-secret \
+  --env=DRONE_SERVER_HOST=drone.company.com \
+  --env=DRONE_SERVER_PROTO=https \
   --publish=80:80 \
   --publish=443:443 \
   --restart=always \


### PR DESCRIPTION
I updated the placeholders in the Gitlab docs with real-life examples. I also highlighted the environment variable lines. Here is the screenshot of my fix
![gitlab](https://user-images.githubusercontent.com/25867172/138618558-e36dd0bf-e07d-41b0-b153-f69fbadc68a4.png)
.
