### PR TITLE
(maint) added real life examples and highlighting to bash command in Gogs Doc

### DIFF
--- a/content/server/provider/gogs.md
+++ b/content/server/provider/gogs.md
@@ -50,14 +50,14 @@ The Drone server is configured using environment variables. This article referen
 
 The server container can be started with the below command. The container is configured through environment variables. _Remember to replace the placeholder values below with the appropriate values._
 
-{{< highlight handlebars "linenos=table" >}}
+{{< highlight bash "linenos=table,hl_lines=3-7" >}}
 docker run \
   --volume=/var/lib/drone:/data \
   --env=DRONE_AGENTS_ENABLED=true \
   --env=DRONE_GOGS_SERVER=https://gogs.company.com \
-  --env=DRONE_RPC_SECRET={{DRONE_RPC_SECRET}} \
-  --env=DRONE_SERVER_HOST={{DRONE_SERVER_HOST}} \
-  --env=DRONE_SERVER_PROTO={{DRONE_SERVER_PROTO}} \
+  --env=DRONE_RPC_SECRET=super-duper-secret \
+  --env=DRONE_SERVER_HOST=drone.company.com \
+  --env=DRONE_SERVER_PROTO=https \
   --publish=80:80 \
   --publish=443:443 \
   --restart=always \


### PR DESCRIPTION
I updated the placeholders in the Gitlab docs with real-life examples. I also highlighted the environment variable lines. Here is the screenshot of my fix.
![gogs](https://user-images.githubusercontent.com/25867172/138618845-fef92645-51bb-4ec9-abdc-9c2ff78013cf.png)
.
