### PR TITLE
(maint) added real life examples and highlighting to bash command in Bitbucket-cloud Doc

### DIFF
--- a/content/server/provider/bitbucket-cloud.md
+++ b/content/server/provider/bitbucket-cloud.md
@@ -83,7 +83,7 @@ The Drone server is configured using environment variables. This article referen
 
 The server container can be started with the below command. The container is configured through environment variables. _Remember to replace the placeholder values below with the appropriate values._
 
-{{< highlight handlebars "linenos=table,hl_lines=3-7" >}}
+{{< highlight bash "linenos=table,hl_lines=3-7" >}}
 docker run \
   --volume=/var/lib/drone:/data \
   --env=DRONE_BITBUCKET_CLIENT_ID=05136e57d80189bef462 \

--- a/content/server/provider/bitbucket-cloud.md
+++ b/content/server/provider/bitbucket-cloud.md
@@ -83,14 +83,14 @@ The Drone server is configured using environment variables. This article referen
 
 The server container can be started with the below command. The container is configured through environment variables. _Remember to replace the placeholder values below with the appropriate values._
 
-{{< highlight handlebars "linenos=table" >}}
+{{< highlight handlebars "linenos=table,hl_lines=3-7" >}}
 docker run \
   --volume=/var/lib/drone:/data \
-  --env=DRONE_BITBUCKET_CLIENT_ID={{DRONE_BITBUCKET_CLIENT_ID}} \
-  --env=DRONE_BITBUCKET_CLIENT_SECRET={{DRONE_BITBUCKET_CLIENT_SECRET}} \
-  --env=DRONE_RPC_SECRET={{DRONE_RPC_SECRET}} \
-  --env=DRONE_SERVER_HOST={{DRONE_SERVER_HOST}} \
-  --env=DRONE_SERVER_PROTO={{DRONE_SERVER_PROTO}} \
+  --env=DRONE_BITBUCKET_CLIENT_ID=05136e57d80189bef462 \
+  --env=DRONE_BITBUCKET_CLIENT_SECRET=7c229228a77d2cbddaa61ddc78d45e \
+  --env=DRONE_RPC_SECRET=super-duper-secret \
+  --env=DRONE_SERVER_HOST=drone.company.com \
+  --env=DRONE_SERVER_PROTO=https \
   --publish=80:80 \
   --publish=443:443 \
   --restart=always \


### PR DESCRIPTION
I updated the placeholders in the Bitbucket-cloud docs with real-life examples. I also highlighted the environment variable lines. Here is the screenshot of my fix.
![bitbucket-cloud](https://user-images.githubusercontent.com/25867172/138962114-3825eafd-278d-4ebe-92bc-270f2ad08e7b.png)


