### PR TITLE
Removed --smallfiles option from mongodb examples

### DIFF
--- a/content/pipeline/docker/examples/services/mongo.md
+++ b/content/pipeline/docker/examples/services/mongo.md
@@ -29,7 +29,6 @@ steps:
 services:
 - name: mongo
   image: mongo:4
-  command: [ --smallfiles ]
 ```
 
 # Common Problems
@@ -69,7 +68,6 @@ steps:
 services:
 - name: mongo
   image: mongo:4
-  command: [ --smallfiles ]
 ```
 
 Good:
@@ -85,5 +83,4 @@ steps:
 services:
 - name: mongo
   image: mongo:4
-  command: [ --smallfiles ]
 ```

--- a/content/pipeline/kubernetes/examples/service/mongo.md
+++ b/content/pipeline/kubernetes/examples/service/mongo.md
@@ -30,7 +30,6 @@ steps:
 services:
 - name: mongo
   image: mongo:4
-  command: [ --smallfiles ]
 ```
 
 # Common Problems


### PR DESCRIPTION
In the drone examples for running mongodb as a service on kubernetes and docker the option `--smallfiles` is included, but this option has been completely removed since mongodb v4.2. The `mongo:4` docker image currently refers to the mongodb v4.4.
This leads to the service being unable to start.

Drone docs:
https://docs.drone.io/pipeline/kubernetes/examples/service/mongo/
https://docs.drone.io/pipeline/docker/examples/services/mongo/

Mongodb changelog:
https://www.mongodb.com/docs/manual/reference/configuration-options/#removed-mmapv1-options