### PR TITLE
CLI "drone secret info": Add missing --name flag

### DIFF
--- a/content/cli/secret/drone-secret-info.md
+++ b/content/cli/secret/drone-secret-info.md
@@ -24,5 +24,5 @@ OPTIONS:
 Example usage:
 
 ```
-$ drone secret info octocat/hello-world my_token
+$ drone secret info octocat/hello-world --name my_token
 ```


### PR DESCRIPTION
This PR adds a missing flag `--name` to the example for the `drone secret info` command.

Running the command as it is right now results in the error "Missing secret name" since the secret name cannot be provided as an argument (see [secret_info.go#L41-L46](https://github.com/harness/drone-cli/blob/059605732b5f92d1e4a5f95602d3bf27c2e36047/drone/secret/secret_info.go#L41-L46)).


Drone docs:
https://docs.drone.io/cli/secret/drone-secret-info/

