### PR TITLE
docs(quickstart): complete quickstart

### DIFF
--- a/content/quickstart/cli.md
+++ b/content/quickstart/cli.md
@@ -16,14 +16,16 @@ You can use the [command line tools]({{< relref "/cli/install" >}}) to run Docke
 
 # Installation
 
-* Install the command line tools on OSX using [Homebrew](https://brew.sh/):
+* Install the command line tools on macOS using [Homebrew](https://brew.sh/):
+
   ```
-  $ brew install drone-cli
+  brew install drone-cli
   ```
 
 * Install the command line tools on Windows using [Scoop](https://scoop.sh/):
+
   ```
-  $ scoop install drone
+  scoop install drone
   ```
 
 # Usage
@@ -31,6 +33,7 @@ You can use the [command line tools]({{< relref "/cli/install" >}}) to run Docke
 The command line runner requires a working Docker installation. Drone executes your pipeline locally on your host machine using your local Docker daemon. _Local execution does not have any communication with the Drone server._
 
 1. Navigate to the root directory of your git repository where your `.drone.yml` file is located. _Here is a basic configuration you can use for testing purposes:_
+
    ```
    kind: pipeline
    type: docker
@@ -45,11 +48,13 @@ The command line runner requires a working Docker installation. Drone executes y
    ```
 
 2. Execute your pipeline from the command line:
+
    ```
-   $ drone exec
+   drone exec
    ```
 
 3. The command streams the pipeline logs to your terminal for analysis. The command returns a non-zero exit code if the pipeline fails.
+
    ```
    $ drone exec
    [test:1] + echo hello
@@ -57,8 +62,6 @@ The command line runner requires a working Docker installation. Drone executes y
    [test:3] + echo world
    [test:4] world
    ```
-
-
 
 <!-- * Example Go configuration:
    ```
@@ -97,6 +100,7 @@ The command line runner mounts your current working directory, using docker volu
 The command line runner runs the _default_ pipeline. If you use a different name for you pipeline, or you define multiple pipelines in your yaml, you can execute a named pipeline using the `--pipeline` flag.
 
 * Example configuration with a pipeline named _test_
+
   ```
   kind: pipeline
   type: docker
@@ -121,11 +125,13 @@ The command line runner runs the _default_ pipeline. If you use a different name
 When running pipelines locally you can limit which pipeline steps are executed and which pipeline steps are skipped.
 
 * Execute only pipeline steps _build_ and _test_
+
    ```
    drone exec --include=build --include=test
    ```
 
 * Execute all pipeline steps except _deploy_
+
    ```
    drone exec --exclude=deploy
    ```
@@ -135,6 +141,7 @@ When running pipelines locally you can limit which pipeline steps are executed a
 The command line runner does not have read access to secrets stored in your server. You can provide secrets to your local pipeline by passing secrets to the command line runner via text file.
 
 1. Example pipeline that requires username and password environment variables, sourced from secrets.
+
    ```
    kind: pipeline
    type: docker
@@ -148,15 +155,18 @@ The command line runner does not have read access to secrets stored in your serv
        PASSWORD:
          from_secret: PASSWORD
    ```
+
 1. Create a simple text file with secrets defined one per line in key value format. _For the purposes of this demo we name the file `secrets.txt`._
+
    ```
    USERNAME=root
    PASSWORD=password
    ```
 
 2. Provide your secrets file via command line flags when executing your pipeline.
+
    ```
-   $ drone exec --secret-file=secrets.txt
+   drone exec --secret-file=secrets.txt
    ```
 
 _The command line runner uses the [dotenv](https://github.com/joho/godotenv) package to read and parse the secrets file. If you are having problems with the secrets file please consult the official package [documentation](https://github.com/joho/godotenv)._
@@ -168,18 +178,21 @@ The command line runner does not communicate with the Drone server and therefore
 You can emulate repository metadata by passing repository and build information to the command line runner using command line flags and environment variables.
 
 * Example command sets the branch:
+
    ```
-   $ drone exec --branch=master
+   drone exec --branch=master
    ```
 
 * Example command sets the build event:
+
    ```
-   $ drone exec --event=pull_request
+   drone exec --event=pull_request
    ```
 
 * Example command set metadata using environment variables:
+
   ```
-  $ DRONE_SYSTEM_HOST=drone.company.com drone exec
+  DRONE_SYSTEM_HOST=drone.company.com drone exec
   ```
 
 # Trusted Mode
@@ -189,7 +202,7 @@ If your pipeline uses configurations that require trusted mode, you can enable t
 * Example command enables trusted mode:
 
   ```
-  $ drone exec --trusted
+  drone exec --trusted
   ```
 
 # Local vs Remote
@@ -200,6 +213,6 @@ The command line runner makes reasonable effort to emulate the server environmen
 
 * The server has access to more data (commit details, repository details, etc). This data needs to be provided to the command line runner to more closely emulate the server environment.
 
-* The server has access to your oauth credentials and uses these credentials to generate a netrc file. These credentials need to be provided to the command line runner to more closely emulate the server environment. 
+* The server has access to your oauth credentials and uses these credentials to generate a netrc file. These credentials need to be provided to the command line runner to more closely emulate the server environment.
 
 * The server has access to repository, organization and encrypted secrets. The command line runner does not have access to secrets or decryption keys stored in the server environment.

--- a/content/quickstart/docker.md
+++ b/content/quickstart/docker.md
@@ -25,7 +25,6 @@ After login you are redirected back to your Drone dashboard. _If this is your fi
 
 Next, search for your repository and click the _Enable_ button. Clicking the enable button adds a webhook to your repository to notify Drone every time you push code. _Please note you must have admin privileges to the repository to enable._
 
-
 # Configure your Pipeline
 
 Next, you need to configure a pipeline by creating a `.drone.yml` file to the root of your git repository. In this file we define a series of steps that are executed every time a webhook is received.
@@ -62,11 +61,10 @@ Here is a quick overview of the variables used in this example:
 
 Please see our pipeline [documentation]({{< relref "/pipeline/docker/overview.md" >}}) for a full list of configuration options.
 
-
-
 ## Additional Examples
 
 * You can add multiple steps to your pipeline:
+
     ```yaml  {linenos=table}
     kind: pipeline
     type: docker
@@ -84,7 +82,8 @@ Please see our pipeline [documentation]({{< relref "/pipeline/docker/overview.md
       - echo bonjour monde
     ```
 
-* You can conditionally [limit]({{< relref "pipeline/docker/syntax/conditions.md" >}}) step execution:
+* You can conditionally [limit]({{< relref "pipeline/docker/syntax/conditions.md" >}}) pipeline steps to execute based on branch or webhook events:
+
     ```yaml  {linenos=table, hl_lines=["15-17"]}
     kind: pipeline
     type: docker
@@ -106,7 +105,8 @@ Please see our pipeline [documentation]({{< relref "/pipeline/docker/overview.md
     ```
 
 * You can even define [multiple pipelines]({{< relref "pipeline/configuration.md#multiple-pipelines" >}}):
-    ```yaml  {linenos=table}
+
+    ```yaml {linenos=table, hl_lines=["5-20"]}
     kind: pipeline
     type: docker
     name: en
@@ -130,6 +130,7 @@ Please see our pipeline [documentation]({{< relref "/pipeline/docker/overview.md
     ```
 
 * You can conditionally [limit]({{< relref "pipeline/docker/syntax/trigger.md" >}}) pipeline execution:
+
     ```yaml  {linenos=table hl_lines=["11-13", "26-28"]}
     kind: pipeline
     type: docker
@@ -162,6 +163,7 @@ Please see our pipeline [documentation]({{< relref "/pipeline/docker/overview.md
     ```
 
 * You can use any [image]({{< relref "pipeline/docker/syntax/images.md" >}}) from any docker registry:
+
     ```yaml  {linenos=table, hl_lines=[7]}
     kind: pipeline
     type: docker
@@ -176,6 +178,7 @@ Please see our pipeline [documentation]({{< relref "/pipeline/docker/overview.md
     ```
 
 * You can define [service containers]({{< relref "pipeline/docker/syntax/services.md" >}}) for integration tests:
+
     ```yaml  {linenos=table, hl_lines=["12-14"]}
     kind: pipeline
     type: docker
@@ -194,6 +197,7 @@ Please see our pipeline [documentation]({{< relref "/pipeline/docker/overview.md
     ```
 
 * You can use [plugins]({{< relref "plugins/_index.md" >}}) to integrate with third party systems and perform common tasks, such as notify, publish or deploy software.
+
     ```yaml  {linenos=table, hl_lines=["12-16"]}
     kind: pipeline
     type: docker
@@ -214,6 +218,7 @@ Please see our pipeline [documentation]({{< relref "/pipeline/docker/overview.md
     ```
 
 * You can also source sensitive parameters from [secrets]({{< relref "secret/_index.md" >}}):
+
     ```yaml  {linenos=table, hl_lines=["16-17"]}
     kind: pipeline
     type: docker

--- a/content/quickstart/kubernetes.md
+++ b/content/quickstart/kubernetes.md
@@ -28,7 +28,6 @@ After login you are redirected back to your Drone dashboard. _If this is your fi
 
 Next, search for your repository and click the _Enable_ button. Clicking the enable button adds a webhook to your repository to notify Drone every time you push code. _Please note you must have admin privileges to the repository to enable._
 
-
 # Configure your Pipeline
 
 Next, you need to configure a pipeline by creating a `.drone.yml` file to the root of your git repository. In this file we define a series of steps that are executed every time a webhook is received.
@@ -65,12 +64,11 @@ Here is a quick overview of the variables used in this example:
 
 Please see our pipeline [documentation]({{< relref "/pipeline/kubernetes/overview.md" >}}) for a full list of configuration options.
 
-
-
 ## Additional Examples
 
 * You can add multiple steps to your pipeline:
-    ```
+
+    ```yaml
     kind: pipeline
     type: kubernetes
     name: greeting
@@ -87,8 +85,9 @@ Please see our pipeline [documentation]({{< relref "/pipeline/kubernetes/overvie
       - echo bonjour monde
     ```
 
-* You can limit pipeline steps based on branch or webhook event:
-    ```
+* You can conditionally [limit]({{< relref "pipeline/docker/syntax/conditions.md" >}}) pipeline steps to execute based on branch or webhook events:
+
+    ```yaml  {linenos=table, hl_lines=["15-17"]}
     kind: pipeline
     type: kubernetes
     name: greeting
@@ -108,8 +107,9 @@ Please see our pipeline [documentation]({{< relref "/pipeline/kubernetes/overvie
         - develop
     ```
 
-* You can even define multiple pipelines:
-    ```
+* You can even define [multiple pipelines]({{< relref "pipeline/configuration.md#multiple-pipelines" >}}):
+
+    ```yaml {linenos=table, hl_lines=["5-20"]}
     kind: pipeline
     type: kubernetes
     name: en
@@ -132,8 +132,9 @@ Please see our pipeline [documentation]({{< relref "/pipeline/kubernetes/overvie
       - echo bonjour monde
     ```
 
-* You can use any image in any container registry:
-    ```
+* You can use any [image]({{< relref "pipeline/docker/syntax/images.md" >}}) from any container registry:
+
+    ```yaml
     kind: pipeline
     type: kubernetes
     name: default


### PR DESCRIPTION
Improve the content of the Quick Start documentation

- Fix irregular `Markdown` writing
- Supplementary documentation links related to some samples
- Updated `OSX` operating system to be named `macOS`