### PR TITLE
refactor(highlight): convert code block declarations from tags to Markdown syntax extensions

### DIFF
--- a/content/pipeline/configuration.md
+++ b/content/pipeline/configuration.md
@@ -125,11 +125,11 @@ name: frontend
 
 steps:
 
-* name: build
+- name: build
   image: node
   commands:
-  * npm install
-  * npm test
+  - npm install
+  - npm test
 ```
 
 ## Multiple Platforms

--- a/content/pipeline/configuration.md
+++ b/content/pipeline/configuration.md
@@ -106,7 +106,7 @@ When running multiple pipelines if any of the sibling pipelines fails further bu
 This may present different behaviour, depending on the scheduling of sibling pipelines. This will give non-deterministic behaviour. 
 </div>
 
-{{< highlight yaml "linenos=table,hl_lines=35-57" >}}
+```yaml {linenos=table, hl_lines=["35-57"]}
 kind: pipeline
 type: docker
 name: backend
@@ -124,18 +124,19 @@ type: docker
 name: frontend
 
 steps:
-- name: build
+
+* name: build
   image: node
   commands:
-  - npm install
-  - npm test
-{{< / highlight >}}
+  * npm install
+  * npm test
+```
 
 ## Multiple Platforms
 
 One common use case for multiple pipelines is to define and execute pipelines for different platforms. For example, execute one pipeline on x86 and another pipeline on arm.
 
-{{< highlight yaml "linenos=table,hl_lines=5-6 20-21" >}}
+```yaml {linenos=table, hl_lines=["5-6", "20-21"]}
 kind: pipeline
 type: docker
 name: amd64
@@ -164,14 +165,14 @@ steps:
   commands:
   - go build
   - go test
-{{< / highlight >}}
 
+```
 
 ## Graph Execution
 
 Drone also supports describing your pipelines as a [directed acyclic graph](https://en.wikipedia.org/wiki/Directed_acyclic_graph). In the below example we fan-out to execute the first two pipelines in parallel, and then once complete, we fan-in to execute the final pipeline.
 
-{{< highlight yaml "linenos=table,hl_lines=35-57" >}}
+```yaml {linenos=table, hl_lines=["35-57"]}
 kind: pipeline
 type: docker
 name: backend
@@ -209,7 +210,7 @@ steps:
 depends_on:
 - backend
 - frontend
-{{< / highlight >}}
+```
 
 # Scripting
 

--- a/content/pipeline/overview.md
+++ b/content/pipeline/overview.md
@@ -24,7 +24,7 @@ Pipelines are configured by placing a `.drone.yml` file in the root of your git 
 
 Example pipeline configuration:
 
-{{< highlight yaml "linenos=table" >}}
+```yaml {linenos=table}
 ---
 kind: pipeline
 type: docker
@@ -44,7 +44,7 @@ steps:
   - npm run test
 
 ...
-{{< / highlight >}}
+```
 
 Drone supports different types of pipelines, each optimized for different use cases and runtime environments:
 
@@ -66,12 +66,12 @@ Pipelines are triggered by webhooks sent from your source control management sys
 # Pipelines
 Drone supports different types of pipeline execution environments, where each type has its own custom yaml specification. The kind and type attributes define the type of pipeline and target execution environment.
 
-{{< highlight text "linenos=table,hl_lines=2-3" >}}
+```yaml {linenos=table, hl_lines=["2-3"] >}}
 ---
 kind: pipeline
 type: docker
 name: default
-{{< / highlight >}}
+```
 
 ## Docker Pipelines
 

--- a/content/pipeline/parallelism.md
+++ b/content/pipeline/parallelism.md
@@ -12,7 +12,7 @@ description: |
 
 Pipeline steps are executed sequentially by default. You can optionally describe your build steps as a [directed acyclic graph](https://en.wikipedia.org/wiki/Directed_acyclic_graph). In the below example we fan-out to execute the first two steps in parallel, and then once complete, we fan-in to execute the final step:
 
-{{< highlight yaml "linenos=table,hl_lines=23-25" >}}
+```yaml {linenos=table, hl_lines=["23-25"]}
 kind: pipeline
 type: docker
 name: default
@@ -38,7 +38,7 @@ steps:
   depends_on:
   - frontend
   - backend
-{{< / highlight >}}
+```
 
 The above example is quite simple, however, you can use this syntax to create very complex execution flows.
 

--- a/content/pipeline/routing.md
+++ b/content/pipeline/routing.md
@@ -15,7 +15,7 @@ The `node` section can be used to route pipelines to specific runners, or groups
 A pipeline is not routed to a runner unless it matches all runner labels. If the pipeline only defines and matches a subset of runner labels it will not be routed to the runner.
 </div>
 
-{{< highlight yaml "linenos=table,hl_lines=12-14" >}}
+```yaml {linenos=table, hl_lines=["12-14"]}
 kind: pipeline
 type: docker
 name: default
@@ -30,13 +30,13 @@ steps:
 node:
   keyA: valueA
   keyB: valueB
-{{< / highlight >}}
+```
 
 # Kubernetes
 
 The `node_selector` section should be used with Kubernetes pipelines to route workloads to specific nodes. Node selection can be used in conjunction with [taints and tolerations]({{< relref "/pipeline/kubernetes/configure/tolerations.md" >}}).
 
-{{< highlight yaml "linenos=table,hl_lines=2 12-14" >}}
+```yaml {linenos=table, hl_lines=["2", "12-14"]}
 kind: pipeline
 type: kubernetes
 name: default
@@ -51,4 +51,4 @@ steps:
 node_selector:
   keyA: valueA
   keyB: valueB
-{{< / highlight >}}
+```


### PR DESCRIPTION
## What does this Pull Request do

- Convert code block declarations in Pipeline documents from tags to Markdown syntax extensions
- not changed for other specific content

## Why do this

- In Drone's documentation, there are numerous references to code block highlighting declarations similar to `{{<highlight yaml "linenos=table" >}} ... {{</ highlight >}}`, which is Bright rendering of Markdown documents has a huge experience barrier, and at the same time makes the reading experience of the document repository code extremely poor.
- In the document, there is another way of writing code block highlighting `` ```yaml {linenos=table} ... ``` ``, the function is to keep the code block style consistent with the above highlighted declaration, This writing method conforms to the Markdown syntax style and is more concise. It is recommended to use this method. This is also the core purpose of this Pull Request.
- In fact, the entire document should have a unified code style for easy maintenance, this Pull Request only deals with the documentation of the Pipeline module