### PR TITLE
Update golang.md

### DIFF
--- a/content/plugins/tutorials/golang.md
+++ b/content/plugins/tutorials/golang.md
@@ -30,23 +30,24 @@ Create a Go program that makes an http request using the Yaml configuration para
 package main
 
 import (
-  "net/http"
-  "os"
+	"net/http"
+	"os"
+	"strings"
 )
 
 func main() {
-  body := strings.NewReader(
-    os.GetEnv("PLUGIN_BODY"),
-  )
+	body := strings.NewReader(
+		os.Getenv("PLUGIN_BODY"),
+	)
 
-  req, err := http.NewRequest(
-    os.GetEnv("PLUGIN_METHOD"),
-    os.GetEnv("PLUGIN_URL"),
-    body,
-  )
-  if err != nil {
-    os.Exit(1)
-  }
+	_, err := http.NewRequest(
+		os.Getenv("PLUGIN_METHOD"),
+		os.Getenv("PLUGIN_URL"),
+		body,
+	)
+	if err != nil {
+		os.Exit(1)
+	}
 }
 ```
 


### PR DESCRIPTION
The current go plugin example code does not work out of the box with go 1.19:

```shell
➜  drone-plugin-go git:(main) ✗ GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o webhook
# github.com/rssnyder/drone-plugin-go
./plugin.go:9:11: undefined: strings
./plugin.go:10:8: undefined: os.GetEnv
./plugin.go:13:3: req declared but not used
./plugin.go:14:8: undefined: os.GetEnv
./plugin.go:15:8: undefined: os.GetEnv
```

- `GetEnv`->`Getenv`
- import `strings`
- use blank identifier
- ran `go fmt`

```shell
➜  drone-plugin-go git:(main) ✗ GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o webhook
➜  drone-plugin-go git:(main) ✗ go fmt
plugin.go
```
