### PR TITLE
fix(template): fix wrong yaml example

### DIFF
--- a/content/template/variables.md
+++ b/content/template/variables.md
@@ -68,7 +68,6 @@ Starlark example usage:
 
 Yaml example usage:
 ```
-Yaml example usage:
 - uid: {{ .repo.uid }}
 ```
 


### PR DESCRIPTION
There is redundant content in the yaml example of template, remove it to avoid misunderstanding.