### PR TITLE
Yaml specification format optimization

### DIFF
--- a/content/yaml/digitalocean.md
+++ b/content/yaml/digitalocean.md
@@ -5,8 +5,6 @@ title_in_card: Digital Ocean Pipeline Specification
 author: bradrydzewski
 weight: 4
 toc: true
-type: spec
-hidden: true
 
 description: |
   Digital Ocean pipeline specification document.

--- a/content/yaml/digitalocean.md
+++ b/content/yaml/digitalocean.md
@@ -5,6 +5,7 @@ title_in_card: Digital Ocean Pipeline Specification
 author: bradrydzewski
 weight: 4
 toc: true
+type: spec
 
 description: |
   Digital Ocean pipeline specification document.

--- a/content/yaml/digitalocean.md
+++ b/content/yaml/digitalocean.md
@@ -18,7 +18,7 @@ This document introduces the data structures that represent the _digitalocean pi
 
 The [`Resource`](#the-resource-interface) interface is implemented by all top-level objects, including the digitalocean [`Pipeline`](#the-pipeline-object).
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 interface Resource {
   kind: string;
   type: string;
@@ -26,7 +26,7 @@ interface Resource {
   concurrency: Concurrency;
   depends_on: string[];
 }
-{{< / highlight >}}
+```
 
 <a id="the-kind-attribute"></a>
 
@@ -64,7 +64,7 @@ Defines a list of pipeline dependencies, used to defer execution of the pipeline
 
 The `Pipeline` is the top-level object used to represent the digitalocean pipeline. The `Pipeline` object implements the [`Resource`](#the-resource-interface) interface.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Pipeline : Resource {
   kind:      string;
   type:      string;
@@ -77,7 +77,7 @@ class Pipeline : Resource {
   steps:     Step[];
   trigger:   Conditions;
 }
-{{< / highlight >}}
+```
 
 <a id="the-kind-attribute"></a>
 
@@ -139,14 +139,14 @@ The conditions used to determine whether or not the pipeline should be skipped. 
 
 The [`Server`](#the-server-object) object configures the server instance.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Server {
   image:   string;
   region:  string;
   size:    string;
   user:    string;
 }
-{{< / highlight >}}
+```
 
 <a id="the-image-attribute"></a>
 
@@ -178,14 +178,14 @@ Configures the username used to authenticate with the server. This is an optiona
 
 The [`Platform`](#the-platform-object) object defines the target os and architecture for the pipeline.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Platform {
   os:      OS;
   arch:    Arch;
   variant: string;
   version: string;
 }
-{{< / highlight >}}
+```
 
 <a id="the-os-attribute"></a>
 
@@ -217,12 +217,12 @@ Defines the operating system version. This is most commonly used in conjunction 
 
 The [`Clone`](#the-clone-object) object defines the clone behavior for the pipeline.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Clone {
   depth:   number;
   disable: boolean;
 }
-{{< / highlight >}}
+```
 
 <a id="the-depth-attribute"></a>
 
@@ -242,7 +242,7 @@ Disables cloning the repository. This is an optional `boolean` value. It can be 
 
 The `Step` object defines a pipeline step.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Step {
   name:        string;
   failure:     Failure;
@@ -251,7 +251,7 @@ class Step {
   when:        Conditions;
   depends_on:  string[];
 }
-{{< / highlight >}}
+```
 
 <a id="the-name-attribute"></a>
 
@@ -295,7 +295,7 @@ Defines a list of steps dependencies, used to defer step execution until the nam
 
 The [`Conditions`](#the-conditions-object) object defines a set of conditions. If any condition evaluates to true its parent object is skipped.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Conditions {
   action:   Constraint | string[];
   branch:   Constraint | string[];
@@ -307,7 +307,7 @@ class Conditions {
   status:   Constraint | Status[];
   target:   Constraint | string[];
 }
-{{< / highlight >}}
+```
 
 <a id="the-action-attribute"></a>
 
@@ -369,12 +369,12 @@ Defines matching criteria based on the target environment. The target environmen
 
 The [`Constraint`](#the-constraint-object) object defines pattern matching criteria. If the pattern matching evaluates to false, the parent object is skipped.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Constraint {
   exclude: string[];
   include: string[];
 }
-{{< / highlight >}}
+```
 
 <a id="the-include-attribute"></a>
 
@@ -394,11 +394,11 @@ List of matching patterns. If any pattern is a match, the parent object is skipp
 
 The [`Secret`](#the-secret-object) defines the named source of a secret.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Secret {
   from_secret: string;
 }
-{{< / highlight >}}
+```
 
 <a id="the-concurrency-object"></a>
 
@@ -406,11 +406,11 @@ class Secret {
 
 The [`Concurrency`](#the-concurrency-object) object defines the concurrency limits for the named pipeline.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Concurrency {
   limit: number;
 }
-{{< / highlight >}}
+```
 
 <a id="the-workspace-object"></a>
 
@@ -418,11 +418,11 @@ class Concurrency {
 
 The [`Workspace`](#the-workspace-object) object defines the path to which the source code is cloned (non-normative) and the default working directory for each pipeline step (non-normative).
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Workspace {
   path: string;
 }
-{{< / highlight >}}
+```
 
 # Enums
 
@@ -432,7 +432,7 @@ class Workspace {
 
 The `Event` enum provides a list of pipeline events. This value represents the event that triggered the pipeline.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum Event {
   cron,
   custom,
@@ -442,7 +442,7 @@ enum Event {
   rollback,
   tag,
 }
-{{< / highlight >}}
+```
 
 <a id="the-status-enum"></a>
 
@@ -450,12 +450,12 @@ enum Event {
 
 The `Status` enum provides a list of pipeline statuses. The default pipeline state is `success`, even if the pipeline is still running.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum Status {
   failure,
   success,
 }
-{{< / highlight >}}
+```
 
 <a id="the-failure-enum"></a>
 
@@ -463,12 +463,12 @@ enum Status {
 
 The `Failure` enum defines a list of failure behaviors. The value `always` indicates a failure will fail the parent process. The value `ignore` indicates the failure is silently ignored.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum Failure {
   always,
   ignore,
 }
-{{< / highlight >}}
+```
 
 <a id="the-os-enum"></a>
 
@@ -476,7 +476,7 @@ enum Failure {
 
 The `OS` enum provides a list of supported operating systems.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum OS {
   darwin,
   dragonfly,
@@ -487,7 +487,7 @@ enum OS {
   solaris,
   windows,
 }
-{{< / highlight >}}
+```
 
 <a id="the-arch-enum"></a>
 
@@ -495,11 +495,11 @@ enum OS {
 
 The `Arch` enum provides a list of supported chip architectures.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum Arch {
   386,
   amd64,
   arm64,
   arm,
 }
-{{< / highlight >}}
+```

--- a/content/yaml/digitalocean.md
+++ b/content/yaml/digitalocean.md
@@ -10,7 +10,9 @@ description: |
   Digital Ocean pipeline specification document.
 ---
 
-This document introduces the data structures that represent the _digitalocean pipeline_. The digitalocean pipeline is a continuous integration pipeline that executes workloads on ephemeral digital ocean droplets. 
+This document introduces the data structures that represent the _digitalocean pipeline_. The digitalocean pipeline is a continuous integration pipeline that executes workloads on ephemeral digital ocean droplets.
+
+<a id="the-resource-interface"></a>
 
 # The `Resource` interface
 
@@ -26,25 +28,37 @@ interface Resource {
 }
 {{< / highlight >}}
 
+<a id="the-kind-attribute"></a>
+
 ## The `kind` attribute
 
 Defines the kind of resource, used to identify the resource implementation. This attribute is of type `string` and is required.
+
+<a id="the-type-attribute"></a>
 
 ## The `type` attribute
 
 Defines the type of resource, used to identify the resource implementation. This attribute is of type `string` and is required.
 
+<a id="the-name-attribute"></a>
+
 ## The `name` attribute
 
 The name of the resource. This value is required and must match `[a-zA-Z0-9_-]`. This value is displayed in the user interface (non-normative) and is used to identify the pipeline (non-normative).
+
+<a id="the-concurrency-attribute"></a>
 
 ## The `concurrency` attribute
 
 Defines the concurrency limits for the pipeline stage. This attribute is of type [`Concurrency`](#the-concurrency-object) and is optional.
 
+<a id="the-depends_on-attribute"></a>
+
 ## The `depends_on` attribute
 
 Defines a list of pipeline dependencies, used to defer execution of the pipeline until the named pipelines are in a completed state. This attribute is an array of type `string` and is optional.
+
+<a id="the-pipeline-object"></a>
 
 # The `Pipeline` object
 
@@ -65,41 +79,61 @@ class Pipeline : Resource {
 }
 {{< / highlight >}}
 
+<a id="the-kind-attribute"></a>
+
 ## The `kind` attribute
 
 The kind of resource. This value must be set to `pipeline`.
+
+<a id="the-type-attribute"></a>
 
 ## The `type` attribute
 
 The type of resource. This value must be set to `digitalocean`.
 
+<a id="the-token-attribute"></a>
+
 ## The `token` attribute
 
 The digital ocean API token. This attribute is of type [`Secret`](#the-secret-object) or of type `string` and is required.
+
+<a id="the-server-section"></a>
 
 ## The `server` section
 
 The server settings used to create and configure the instance. This attribute is of type [`Server`](#the-server-object) and is required.
 
+<a id="the-platform-section"></a>
+
 ## The `platform` section
 
 The target operating system and architecture on which the pipeline must execute. This attribute is of type [`Platform`](#the-platform-object) and is recommended. If empty, the default operating system and architecture may be `linux` and `amd64` respectively.
+
+<a id="the-workspace-section"></a>
 
 ## The `workspace` section
 
 The working directory where the source code is cloned and the default working directory for each pipeline step. This attribute is of type [`Workspace`](#the-workspace-object) and is optional.
 
+<a id="the-clone-section"></a>
+
 ## The `clone` section
 
 Defines the pipeline clone behavior and can be used to disable automatic cloning. This attribute is of type [`Clone`](#the-clone-object) and is optional.
+
+<a id="the-steps-section"></a>
 
 ## The `steps` section
 
 Defines the pipeline steps. This attribute is an array of type [`Step`](#the-step-object) and is required. The array must not be empty and the order of the array must be retained.
 
+<a id="the-trigger-section"></a>
+
 ## The `trigger` section
 
 The conditions used to determine whether or not the pipeline should be skipped. This attribute is of type [`Conditions`](#the-conditions-object) and is optional.
+
+<a id="the-server-object"></a>
 
 # The `Server` object
 
@@ -114,21 +148,31 @@ class Server {
 }
 {{< / highlight >}}
 
+<a id="the-image-attribute"></a>
+
 ## The `image` attribute
 
 Configures the image type. The default value is `docker-18-04`. This is an optional `string` value.
+
+<a id="the-region-attribute"></a>
 
 ## The `region` attribute
 
 Configures the instance region. The default value is `nyc1`. This is an optional `string` value.
 
+<a id="the-size-attribute"></a>
+
 ## The `size` attribute
 
 Configures the instance size. The default value is `s-1vcpu-1gb`. This is an optional `string` value.
 
+<a id="the-user-attribute"></a>
+
 ## The `user` attribute
 
 Configures the username used to authenticate with the server. This is an optional `string` value.
+
+<a id="the-platform-object"></a>
 
 # The `Platform` object
 
@@ -143,21 +187,31 @@ class Platform {
 }
 {{< / highlight >}}
 
+<a id="the-os-attribute"></a>
+
 ## The `os` attribute
 
 Defines the target operating system. The attribute is an enumeration of type `OS` and is recommended. If empty the operating system may default to Linux.
+
+<a id="the-arch-attribute"></a>
 
 ## The `arch` attribute
 
 Defines the target architecture. The attribute is an enumeration of type `Arch` and is recommended. If empty the architecture may default to amd64.
 
+<a id="the-variant-attribute"></a>
+
 ## The `variant` attribute
 
 Defines the architecture variant. This is most commonly used in conjunction with the arm architecture (non-normative) and can be used to differentiate between armv7, armv8, and so on (non-normative).
 
+<a id="the-version-attribute"></a>
+
 ## The `version` attribute
 
 Defines the operating system version. This is most commonly used in conjunction with the windows operating system (non-normative) and can be used to differentiate between 1809, 1903, and so on (non-normative).
+
+<a id="the-clone-object"></a>
 
 # The `Clone` object
 
@@ -170,13 +224,19 @@ class Clone {
 }
 {{< / highlight >}}
 
+<a id="the-depth-attribute"></a>
+
 ## The `depth` attribute
 
 Configures the clone depth. This is an optional `number` value. If empty the full repository may be cloned (non-normative).
 
+<a id="the-disable-attribute"></a>
+
 ## The `disable` attribute
 
 Disables cloning the repository. This is an optional `boolean` value. It can be useful when you need to disable implement your own custom clone logic (non-normative).
+
+<a id="the-step-object"></a>
 
 # The `Step` object
 
@@ -193,29 +253,43 @@ class Step {
 }
 {{< / highlight >}}
 
+<a id="the-name-attribute"></a>
+
 ## The `name` attribute
 
-The name of the step. This value is required and must match [a-zA-Z0-9_-]. This value is displayed in the user interface (non-normative) and is used to identify the step (non-normative). 
+The name of the step. This value is required and must match [a-zA-Z0-9_-]. This value is displayed in the user interface (non-normative) and is used to identify the step (non-normative).
+
+<a id="the-failure-attribute"></a>
 
 ## The `failure` attribute
 
 Defines how the system handles failure. The default value is `always` indicating a failed step always fails the overall pipeline. A value of `ignore` indicates the failure is ignored. This attribute is of enumeration `Failure` and is optional.
 
+<a id="the-commands-attribute"></a>
+
 ## The `commands` attribute
 
 Defines a list of shell commands executed on the host machine. This attribute is an array of type `string` and is required.
+
+<a id="the-environment-attribute"></a>
 
 ## The `environment` attribute
 
 Defines a list of environment variables scoped to the pipeline step. This attribute is of type `[string, string]` and is optional.
 
+<a id="the-when-section"></a>
+
 ## The `when` section
 
 The conditions used to determine whether or not the step should be skipped. This attribute is of type [`Conditions`](#the-conditions-object) and is optional.
 
+<a id="the-depends_on-attribute"></a>
+
 ## The `depends_on` attribute
 
 Defines a list of steps dependencies, used to defer step execution until the named steps are in a completed state. This attribute is of type `string` and is optional.
+
+<a id="the-conditions-object"></a>
 
 # The `Conditions` object
 
@@ -235,41 +309,61 @@ class Conditions {
 }
 {{< / highlight >}}
 
+<a id="the-action-attribute"></a>
+
 ## The `action` attribute
 
 Defines matching criteria based on the build action. The build action is synonymous with a webhook action (non-normative). This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
+
+<a id="the-branch-attribute"></a>
 
 ## The `branch` attribute
 
 Defines matching criteria based on the git branch. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
 
+<a id="the-cron-attribute"></a>
+
 ## The `cron` attribute
 
 Defines matching criteria based on the cron job that triggered the build. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
+
+<a id="the-event-attribute"></a>
 
 ## The `event` attribute
 
 Defines matching criteria based on the build event. The build event is synonymous with a webhook event (non-normative). This attribute is of type [`Constraint`](#the-constraint-object) or an array of type [`Event`](#the-event-enum) and is optional.
 
+<a id="the-instance-attribute"></a>
+
 ## The `instance` attribute
 
 Defines matching criteria based on the instance hostname. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
+
+<a id="the-ref-attribute"></a>
 
 ## The `ref` attribute
 
 Defines matching criteria based on the git reference. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
 
+<a id="the-repo-attribute"></a>
+
 ## The `repo` attribute
 
 Defines matching criteria based on the repository name. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
+
+<a id="the-status-attribute"></a>
 
 ## The `status` attribute
 
 Defines matching criteria based on the pipeline status. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type [`Status`](#the-status-enum) and is optional.
 
+<a id="the-target-attribute"></a>
+
 ## The `target` attribute
 
 Defines matching criteria based on the target environment. The target environment is typically defined by a promote or rollback event (non-normative). This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
+
+<a id="the-constraint-object"></a>
 
 # The `Constraint` object
 
@@ -282,13 +376,19 @@ class Constraint {
 }
 {{< / highlight >}}
 
+<a id="the-include-attribute"></a>
+
 ## The `include` attribute
 
 List of matching patterns. If no pattern is a match, the parent object is skipped. This attribute is an array of type `string` and is optional.
 
+<a id="the-exclude-attribute"></a>
+
 ## The `exclude` attribute
 
 List of matching patterns. If any pattern is a match, the parent object is skipped. This attribute is an array of type `string` and is optional.
+
+<a id="the-secret-object"></a>
 
 # The `Secret` object
 
@@ -300,6 +400,8 @@ class Secret {
 }
 {{< / highlight >}}
 
+<a id="the-concurrency-object"></a>
+
 # The `Concurrency` object
 
 The [`Concurrency`](#the-concurrency-object) object defines the concurrency limits for the named pipeline.
@@ -309,6 +411,8 @@ class Concurrency {
   limit: number;
 }
 {{< / highlight >}}
+
+<a id="the-workspace-object"></a>
 
 # The `Workspace` object
 
@@ -321,6 +425,8 @@ class Workspace {
 {{< / highlight >}}
 
 # Enums
+
+<a id="the-event-enum"></a>
 
 ## The `Event` enum
 
@@ -338,6 +444,8 @@ enum Event {
 }
 {{< / highlight >}}
 
+<a id="the-status-enum"></a>
+
 ## The `Status` enum
 
 The `Status` enum provides a list of pipeline statuses. The default pipeline state is `success`, even if the pipeline is still running.
@@ -349,6 +457,8 @@ enum Status {
 }
 {{< / highlight >}}
 
+<a id="the-failure-enum"></a>
+
 ## The `Failure` enum
 
 The `Failure` enum defines a list of failure behaviors. The value `always` indicates a failure will fail the parent process. The value `ignore` indicates the failure is silently ignored.
@@ -359,6 +469,8 @@ enum Failure {
   ignore,
 }
 {{< / highlight >}}
+
+<a id="the-os-enum"></a>
 
 ## The `OS` enum
 
@@ -376,6 +488,8 @@ enum OS {
   windows,
 }
 {{< / highlight >}}
+
+<a id="the-arch-enum"></a>
 
 ## The `Arch` enum
 

--- a/content/yaml/docker.md
+++ b/content/yaml/docker.md
@@ -5,6 +5,7 @@ title_in_card: Docker Pipeline Specification
 author: bradrydzewski
 weight: 4
 toc: true
+type: spec
 
 description: |
   Docker pipeline specification document.

--- a/content/yaml/docker.md
+++ b/content/yaml/docker.md
@@ -11,7 +11,9 @@ description: |
 ---
 
 
-This document introduces the data structures that represent the _docker pipeline_. The Docker pipeline is a continuous integration pipeline that executes pipeline steps inside isolated Docker containers. 
+This document introduces the data structures that represent the _docker pipeline_. The Docker pipeline is a continuous integration pipeline that executes pipeline steps inside isolated Docker containers.
+
+<a id="the-resource-interface"></a>
 
 # The `Resource` interface
 
@@ -27,25 +29,37 @@ interface Resource {
 }
 {{< / highlight >}}
 
+<a id="the-kind-attribute"></a>
+
 ## The `kind` attribute
 
 Defines the kind of resource, used to identify the resource implementation. This attribute is of type `string` and is required.
+
+<a id="the-type-attribute"></a>
 
 ## The `type` attribute
 
 Defines the type of resource, used to identify the resource implementation. This attribute is of type `string` and is required.
 
+<a id="the-name-attribute"></a>
+
 ## The `name` attribute
 
 The name of the resource. This value is required and must match `[a-zA-Z0-9_-]`. This value is displayed in the user interface (non-normative) and is used to identify the pipeline (non-normative).
+
+<a id="the-concurrency-attribute"></a>
 
 ## The `concurrency` attribute
 
 Defines the concurrency limits for the pipeline stage. This attribute is of type [`Concurrency`](#the-concurrency-object) and is optional.
 
+<a id="the-depends_on-attribute"></a>
+
 ## The `depends_on` attribute
 
 Defines a list of pipeline dependencies, used to defer execution of the pipeline until the named pipelines are in a completed state. This attribute is an array of type `string` and is optional.
+
+<a id="the-pipeline-object"></a>
 
 # The `Pipeline` object
 
@@ -68,41 +82,61 @@ class Pipeline : Resource {
 }
 {{< / highlight >}}
 
+<a id="the-kind-attribute"></a>
+
 ## The `kind` attribute
 
 The kind of resource. This value must be set to `pipeline`.
+
+<a id="the-type-attribute"></a>
 
 ## The `type` attribute
 
 The type of resource. This value must be set to `docker`.
 
+<a id="the-platform-section"></a>
+
 ## The `platform` section
 
 The target operating system and architecture on which the pipeline must execute. This attribute is of type [`Platform`](#the-platform-object) and is recommended. If empty, the default operating system and architecture may be `linux` and `amd64` respectively.
+
+<a id="the-workspace-section"></a>
 
 ## The `workspace` section
 
 The working directory where the source code is cloned and the default working directory for each pipeline step. This attribute is of type [`Workspace`](#the-workspace-object) and is optional.
 
+<a id="the-clone-section"></a>
+
 ## The `clone` section
 
 Defines the pipeline clone behavior and can be used to disable automatic cloning. This attribute is of type [`Clone`](#the-clone-object) and is optional.
+
+<a id="the-steps-section"></a>
 
 ## The `steps` section
 
 Defines the pipeline steps. This attribute is an array of type [`Step`](#the-step-object) and is required. The array must not be empty and the order of the array must be retained.
 
+<a id="the-node-attribute"></a>
+
 ## The `node` attribute
 
 Defines key value pairs used to route the pipeline to a specific runner or group of runners. This attribute is of type `[string, string]` and is optional.
+
+<a id="the-trigger-section"></a>
 
 ## The `trigger` section
 
 The conditions used to determine whether or not the pipeline should be skipped. This attribute is of type [`Conditions`](#the-conditions-object) and is optional.
 
+<a id="the-image_pull_secrets-attribute"></a>
+
 ## The `image_pull_secrets` attribute
 
 The list of secrets used to pull private Docker images; This attribute is an array of type `string` and is optional.
+
+<a id="the-platform-object"></a>
 
 # The `Platform` object
 
@@ -117,21 +151,31 @@ class Platform {
 }
 {{< / highlight >}}
 
+<a id="the-os-attribute"></a>
+
 ## The `os` attribute
 
 Defines the target operating system. The attribute is an enumeration of type `OS` and is recommended. If empty the operating system may default to Linux.
+
+<a id="the-arch-attribute"></a>
 
 ## The `arch` attribute
 
 Defines the target architecture. The attribute is an enumeration of type `Arch` and is recommended. If empty the architecture may default to amd64.
 
+<a id="the-variant-attribute"></a>
+
 ## The `variant` attribute
 
 Defines the architecture variant. This is most commonly used in conjunction with the arm architecture (non-normative) and can be used to differentiate between armv7, armv8, and so on (non-normative).
 
+<a id="the-version-attribute"></a>
+
 ## The `version` attribute
 
 Defines the operating system version. This is most commonly used in conjunction with the windows operating system (non-normative) and can be used to differentiate between 1809, 1903, and so on (non-normative).
+
+<a id="the-clone-object"></a>
 
 # The `Clone` object
 
@@ -144,13 +188,19 @@ class Clone {
 }
 {{< / highlight >}}
 
+<a id="the-depth-attribute"></a>
+
 ## The `depth` attribute
 
 Configures the clone depth. This is an optional `number` value. If empty the full repository may be cloned (non-normative).
 
+<a id="the-disable-attribute"></a>
+
 ## The `disable` attribute
 
 Disables cloning the repository. This is an optional `boolean` value. It can be useful when you need to disable implement your own custom clone logic (non-normative).
+
+<a id="the-step-object"></a>
 
 # The `Step` object
 
@@ -176,62 +226,91 @@ class Step {
 }
 {{< / highlight >}}
 
+<a id="the-commands-attribute"></a>
 
 ## The `commands` attribute
 
 Defines a list of shell commands executed inside the Docker container. The commands are executed using the default container shell (non-normative) as the container `ENTRYPOINT`. This attribute is an array of type `string` and is required.
 
+<a id="the-command-attribute"></a>
+
 ## The `command` attribute
 
 Overrides the image `COMMAND`. This should only be used with service containers and cannot not be used with the `commands` attribute. This attribute is an array of type `[string]` and is optional.
+
+<a id="the-detach-attribute"></a>
 
 ## The `detach` attribute
 
 The detach attribute instructions the system to start the Docker container and then run in the background. This value is of type `boolean` and is optional.
 
+<a id="the-entrypoint-attribute"></a>
+
 ## The `entrypoint` attribute
 
 Overrides the image `ENTRYPOINT`. This should only be used with service containers and cannot not be used with the `commands` attribute. This attribute is an array of type `[string]` and is optional.
+
+<a id="the-environment-attribute"></a>
 
 ## The `environment` attribute
 
 Defines a list of environment variables scoped to the pipeline step. This attribute is of type `[string, string | Secret]` and is optional.
 
+<a id="the-failure-attribute"></a>
+
 ## The `failure` attribute
 
 Defines how the system handles failure. The default value is `always` indicating a failed step always fails the overall pipeline. A value of `ignore` indicates the failure is ignored. This attribute is of enumeration [`Failure`](#the-failure-enum) and is optional.
+
+<a id="the-image-attribute"></a>
 
 ## The `image` attribute
 
 The name of the docker image. The image name should include the tag and will default to the latest tag if unspecified. This value is of type `string` and is required.
 
+<a id="the-name-attribute"></a>
+
 ## The `name` attribute
 
 The name of the step. This value is required and must match [a-zA-Z0-9_-]. This value is displayed in the user interface (non-normative) and is used to identify the step (non-normative).
+
+<a id="the-network_mode-attribute"></a>
 
 ## The `network_mode` attribute
 
 Overrides the default network to which the Docker container is attached. For example `host` or `bridge`. This attribute is of type `string` and is optional.
 
+<a id="the-privileged-attribute"></a>
+
 ## The `privileged` attribute
 
 Overrides the default Docker security policy and grants the container nearly full access to the host machine. This attribute is of type `boolean` and is optional.
+
+<a id="the-pull-attribute"></a>
 
 ## The `pull` attribute
 
 Defines how and when the system should pull images. This attribute is of enumeration [`Pull`](#the-pull-enum) and is optional.
 
+<a id="the-user-attribute"></a>
+
 ## The `user` attribute
 
 Overrides the default username or uid used when executing the pipeline commands or entrypoint. This attribute is of type `string` and is optional.
+
+<a id="the-when-section"></a>
 
 ## The `when` section
 
 The conditions used to determine whether or not the step should be skipped. This attribute is of type [`Conditions`](#the-conditions-object) and is optional.
 
+<a id="the-depends_on-attribute"></a>
+
 ## The `depends_on` attribute
 
 Defines a list of steps dependencies, used to defer step execution until the named steps are in a completed state. This attribute is of type `string` and is optional.
+
+<a id="the-conditions-object"></a>
 
 # The `Conditions` object
 
@@ -251,41 +330,61 @@ class Conditions {
 }
 {{< / highlight >}}
 
+<a id="the-action-attribute"></a>
+
 ## The `action` attribute
 
 Defines matching criteria based on the build action. The build action is synonymous with a webhook action (non-normative). This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
+
+<a id="the-branch-attribute"></a>
 
 ## The `branch` attribute
 
 Defines matching criteria based on the git branch. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
 
+<a id="the-cron-attribute"></a>
+
 ## The `cron` attribute
 
 Defines matching criteria based on the cron job that triggered the build. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
+
+<a id="the-event-attribute"></a>
 
 ## The `event` attribute
 
 Defines matching criteria based on the build event. The build event is synonymous with a webhook event (non-normative). This attribute is of type [`Constraint`](#the-constraint-object) or an array of type [`Event`](#the-event-enum) and is optional.
 
+<a id="the-instance-attribute"></a>
+
 ## The `instance` attribute
 
 Defines matching criteria based on the instance hostname. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
+
+<a id="the-ref-attribute"></a>
 
 ## The `ref` attribute
 
 Defines matching criteria based on the git reference. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
 
+<a id="the-repo-attribute"></a>
+
 ## The `repo` attribute
 
 Defines matching criteria based on the repository name. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
+
+<a id="the-status-attribute"></a>
 
 ## The `status` attribute
 
 Defines matching criteria based on the pipeline status. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type [`Status`](#the-status-enum) and is optional.
 
+<a id="the-target-attribute"></a>
+
 ## The `target` attribute
 
 Defines matching criteria based on the target environment. The target environment is typically defined by a promote or rollback event (non-normative). This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
+
+<a id="the-constraint-object"></a>
 
 # The `Constraint` object
 
@@ -298,13 +397,19 @@ class Constraint {
 }
 {{< / highlight >}}
 
+<a id="the-include-attribute"></a>
+
 ## The `include` attribute
 
 List of matching patterns. If no pattern is a match, the parent object is skipped. This attribute is an array of type `string` and is optional.
 
+<a id="the-exclude-attribute"></a>
+
 ## The `exclude` attribute
 
 List of matching patterns. If any pattern is a match, the parent object is skipped. This attribute is an array of type `string` and is optional.
+
+<a id="the-secret-object"></a>
 
 # The `Secret` object
 
@@ -316,6 +421,8 @@ class Secret {
 }
 {{< / highlight >}}
 
+<a id="the-concurrency-object"></a>
+
 # The `Concurrency` object
 
 The [`Concurrency`](#the-concurrency-object) object defines the concurrency limits for the named pipeline.
@@ -325,6 +432,8 @@ class Concurrency {
   limit: number;
 }
 {{< / highlight >}}
+
+<a id="the-workspace-object"></a>
 
 # The `Workspace` object
 
@@ -337,6 +446,8 @@ class Workspace {
 {{< / highlight >}}
 
 # Enums
+
+<a id="the-event-enum"></a>
 
 ## The `Event` enum
 
@@ -354,6 +465,8 @@ enum Event {
 }
 {{< / highlight >}}
 
+<a id="the-status-enum"></a>
+
 ## The `Status` enum
 
 The `Status` enum provides a list of pipeline statuses. The default pipeline state is `success`, even if the pipeline is still running.
@@ -364,6 +477,8 @@ enum Status {
   success,
 }
 {{< / highlight >}}
+
+<a id="the-pull-enum"></a>
 
 ## The `Pull` enum
 
@@ -377,6 +492,8 @@ enum Pull {
 }
 {{< / highlight >}}
 
+<a id="the-failure-enum"></a>
+
 ## The `Failure` enum
 
 The `Failure` enum defines a list of failure behaviors. The value `always` indicates a failure will fail the parent process. The value `ignore` indicates the failure is silently ignored.
@@ -387,6 +504,8 @@ enum Failure {
   ignore,
 }
 {{< / highlight >}}
+
+<a id="the-os-enum"></a>
 
 ## The `OS` enum
 
@@ -404,6 +523,8 @@ enum OS {
   windows,
 }
 {{< / highlight >}}
+
+<a id="the-arch-enum"></a>
 
 ## The `Arch` enum
 

--- a/content/yaml/docker.md
+++ b/content/yaml/docker.md
@@ -19,7 +19,7 @@ This document introduces the data structures that represent the _docker pipeline
 
 The [`Resource`](#the-resource-interface) interface is implemented by all top-level objects, including the docker [`Pipeline`](#the-pipeline-object).
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 interface Resource {
   kind: string;
   type: string;
@@ -27,7 +27,7 @@ interface Resource {
   concurrency: Concurrency;
   depends_on: string[];
 }
-{{< / highlight >}}
+```
 
 <a id="the-kind-attribute"></a>
 
@@ -65,7 +65,7 @@ Defines a list of pipeline dependencies, used to defer execution of the pipeline
 
 The [`Pipeline`](#the-pipeline-object) is the top-level object used to represent the docker pipeline. The [`Pipeline`](#the-pipeline-object) object implements the [`Resource`](#the-resource-interface) interface.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Pipeline : Resource {
   kind:      string;
   type:      string;
@@ -80,7 +80,7 @@ class Pipeline : Resource {
 
   image_pull_secrets: string[]
 }
-{{< / highlight >}}
+```
 
 <a id="the-kind-attribute"></a>
 
@@ -142,14 +142,14 @@ The list of secrets used to pull private Docker images; This attribute is an arr
 
 The [`Platform`](#the-platform-object) object defines the target os and architecture for the pipeline.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Platform {
   os:      OS;
   arch:    Arch;
   variant: string;
   version: string;
 }
-{{< / highlight >}}
+```
 
 <a id="the-os-attribute"></a>
 
@@ -181,12 +181,12 @@ Defines the operating system version. This is most commonly used in conjunction 
 
 The [`Clone`](#the-clone-object) object defines the clone behavior for the pipeline.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Clone {
   depth:   number;
   disable: boolean;
 }
-{{< / highlight >}}
+```
 
 <a id="the-depth-attribute"></a>
 
@@ -206,7 +206,7 @@ Disables cloning the repository. This is an optional `boolean` value. It can be 
 
 The `Step` object defines a pipeline step.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Step {
   command:      string[];
   commands:     string[];
@@ -224,7 +224,7 @@ class Step {
   when:         Conditions;
   depends_on:   string[];
 }
-{{< / highlight >}}
+```
 
 <a id="the-commands-attribute"></a>
 
@@ -316,7 +316,7 @@ Defines a list of steps dependencies, used to defer step execution until the nam
 
 The [`Conditions`](#the-conditions-object) object defines a set of conditions. If any condition evaluates to true its parent object is skipped.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Conditions {
   action:   Constraint | string[];
   branch:   Constraint | string[];
@@ -328,7 +328,7 @@ class Conditions {
   status:   Constraint | Status[];
   target:   Constraint | string[];
 }
-{{< / highlight >}}
+```
 
 <a id="the-action-attribute"></a>
 
@@ -390,12 +390,12 @@ Defines matching criteria based on the target environment. The target environmen
 
 The [`Constraint`](#the-constraint-object) object defines pattern matching criteria. If the pattern matching evaluates to false, the parent object is skipped.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Constraint {
   exclude: string[];
   include: string[];
 }
-{{< / highlight >}}
+```
 
 <a id="the-include-attribute"></a>
 
@@ -415,11 +415,11 @@ List of matching patterns. If any pattern is a match, the parent object is skipp
 
 The [`Secret`](#the-secret-object) defines the named source of a secret.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Secret {
   from_secret: string;
 }
-{{< / highlight >}}
+```
 
 <a id="the-concurrency-object"></a>
 
@@ -427,11 +427,11 @@ class Secret {
 
 The [`Concurrency`](#the-concurrency-object) object defines the concurrency limits for the named pipeline.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Concurrency {
   limit: number;
 }
-{{< / highlight >}}
+```
 
 <a id="the-workspace-object"></a>
 
@@ -439,11 +439,11 @@ class Concurrency {
 
 The [`Workspace`](#the-workspace-object) object defines the path to which the source code is cloned (non-normative) and the default working directory for each pipeline step (non-normative).
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Workspace {
   path: string;
 }
-{{< / highlight >}}
+```
 
 # Enums
 
@@ -453,7 +453,7 @@ class Workspace {
 
 The `Event` enum provides a list of pipeline events. This value represents the event that triggered the pipeline.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum Event {
   cron,
   custom,
@@ -463,7 +463,7 @@ enum Event {
   rollback,
   tag,
 }
-{{< / highlight >}}
+```
 
 <a id="the-status-enum"></a>
 
@@ -471,12 +471,12 @@ enum Event {
 
 The `Status` enum provides a list of pipeline statuses. The default pipeline state is `success`, even if the pipeline is still running.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum Status {
   failure,
   success,
 }
-{{< / highlight >}}
+```
 
 <a id="the-pull-enum"></a>
 
@@ -484,13 +484,13 @@ enum Status {
 
 The `Pull` enum defines if and when a docker image should be pull from the registry.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum Pull {
   always,
   never,
   if-not-exists,
 }
-{{< / highlight >}}
+```
 
 <a id="the-failure-enum"></a>
 
@@ -498,12 +498,12 @@ enum Pull {
 
 The `Failure` enum defines a list of failure behaviors. The value `always` indicates a failure will fail the parent process. The value `ignore` indicates the failure is silently ignored.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum Failure {
   always,
   ignore,
 }
-{{< / highlight >}}
+```
 
 <a id="the-os-enum"></a>
 
@@ -511,7 +511,7 @@ enum Failure {
 
 The `OS` enum provides a list of supported operating systems.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum OS {
   darwin,
   dragonfly,
@@ -522,7 +522,7 @@ enum OS {
   solaris,
   windows,
 }
-{{< / highlight >}}
+```
 
 <a id="the-arch-enum"></a>
 
@@ -530,11 +530,11 @@ enum OS {
 
 The `Arch` enum provides a list of supported chip architectures.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum Arch {
   386,
   amd64,
   arm64,
   arm,
 }
-{{< / highlight >}}
+```

--- a/content/yaml/docker.md
+++ b/content/yaml/docker.md
@@ -5,8 +5,6 @@ title_in_card: Docker Pipeline Specification
 author: bradrydzewski
 weight: 4
 toc: true
-type: spec
-hidden: true
 
 description: |
   Docker pipeline specification document.

--- a/content/yaml/exec.md
+++ b/content/yaml/exec.md
@@ -12,6 +12,8 @@ description: |
 
 This document introduces the data structures that represent the _exec pipeline_. The exec pipeline is a continuous integration pipeline that executes commands directly on the host machine.
 
+<a id="the-resource-interface"></a>
+
 # The `Resource` interface
 
 The [`Resource`](#the-resource-interface) interface is implemented by all top-level objects, including the exec [`Pipeline`](#the-pipeline-object).
@@ -26,25 +28,37 @@ interface Resource {
 }
 {{< / highlight >}}
 
+<a id="the-kind-attribute"></a>
+
 ## The `kind` attribute
 
 Defines the kind of resource, used to identify the resource implementation. This attribute is of type `string` and is required.
+
+<a id="the-type-attribute"></a>
 
 ## The `type` attribute
 
 Defines the type of resource, used to identify the resource implementation. This attribute is of type `string` and is required.
 
+<a id="the-name-attribute"></a>
+
 ## The `name` attribute
 
 The name of the resource. This value is required and must match `[a-zA-Z0-9_-]`. This value is displayed in the user interface (non-normative) and is used to identify the pipeline (non-normative).
+
+<a id="the-concurrency-attribute"></a>
 
 ## The `concurrency` attribute
 
 Defines the concurrency limits for the pipeline stage. This attribute is of type [`Concurrency`](#the-concurrency-object) and is optional.
 
+<a id="the-depends_on-attribute"></a>
+
 ## The `depends_on` attribute
 
 Defines a list of pipeline dependencies, used to defer execution of the pipeline until the named pipelines are in a completed state. This attribute is an array of type `string` and is optional.
+
+<a id="the-pipeline-object"></a>
 
 # The `Pipeline` object
 
@@ -63,33 +77,49 @@ class Pipeline : Resource {
 }
 {{< / highlight >}}
 
+<a id="the-kind-attribute"></a>
+
 ## The `kind` attribute
 
 The kind of resource. This value must be set to `pipeline`.
+
+<a id="the-type-attribute"></a>
 
 ## The `type` attribute
 
 The type of resource. This value must be set to `exec`.
 
+<a id="the-platform-section"></a>
+
 ## The `platform` section
 
 The target operating system and architecture on which the pipeline must execute. This attribute is of type [`Platform`](#the-platform-object) and is recommended. If empty, the default operating system and architecture may be `linux` and `amd64` respectively.
+
+<a id="the-workspace-section"></a>
 
 ## The `workspace` section
 
 The working directory where the source code is cloned and the default working directory for each pipeline step. This attribute is of type [`Workspace`](#the-workspace-object) and is optional.
 
+<a id="the-clone-section"></a>
+
 ## The `clone` section
 
 Defines the pipeline clone behavior and can be used to disable automatic cloning. This attribute is of type [`Clone`](#the-clone-object) and is optional.
+
+<a id="the-steps-section"></a>
 
 ## The `steps` section
 
 Defines the pipeline steps. This attribute is an array of type [`Step`](#the-step-object) and is required. The array must not be empty and the order of the array must be retained.
 
+<a id="the-trigger-section"></a>
+
 ## The `trigger` section
 
 The conditions used to determine whether or not the pipeline should be skipped. This attribute is of type [`Conditions`](#the-conditions-object) and is optional.
+
+<a id="the-platform-object"></a>
 
 # The `Platform` object
 
@@ -104,21 +134,31 @@ class Platform {
 }
 {{< / highlight >}}
 
+<a id="the-os-attribute"></a>
+
 ## The `os` attribute
 
 Defines the target operating system. The attribute is an enumeration of type `OS` and is recommended. If empty the operating system may default to Linux.
+
+<a id="the-arch-attribute"></a>
 
 ## The `arch` attribute
 
 Defines the target architecture. The attribute is an enumeration of type `Arch` and is recommended. If empty the architecture may default to amd64.
 
+<a id="the-variant-attribute"></a>
+
 ## The `variant` attribute
 
 Defines the architecture variant. This is most commonly used in conjunction with the arm architecture (non-normative) and can be used to differentiate between armv7, armv8, and so on (non-normative).
 
+<a id="the-version-attribute"></a>
+
 ## The `version` attribute
 
 Defines the operating system version. This is most commonly used in conjunction with the windows operating system (non-normative) and can be used to differentiate between 1809, 1903, and so on (non-normative).
+
+<a id="the-clone-object"></a>
 
 # The `Clone` object
 
@@ -131,13 +171,19 @@ class Clone {
 }
 {{< / highlight >}}
 
+<a id="the-depth-attribute"></a>
+
 ## The `depth` attribute
 
 Configures the clone depth. This is an optional `number` value. If empty the full repository may be cloned (non-normative).
 
+<a id="the-disable-attribute"></a>
+
 ## The `disable` attribute
 
 Disables cloning the repository. This is an optional `boolean` value. It can be useful when you need to disable implement your own custom clone logic (non-normative).
+
+<a id="the-step-object"></a>
 
 # The `Step` object
 
@@ -154,29 +200,43 @@ class Step {
 }
 {{< / highlight >}}
 
+<a id="the-name-attribute"></a>
+
 ## The `name` attribute
 
-The name of the step. This value is required and must match [a-zA-Z0-9_-]. This value is displayed in the user interface (non-normative) and is used to identify the step (non-normative). 
+The name of the step. This value is required and must match [a-zA-Z0-9_-]. This value is displayed in the user interface (non-normative) and is used to identify the step (non-normative).
+
+<a id="the-failure-attribute"></a>
 
 ## The `failure` attribute
 
 Defines how the system handles failure. The default value is `always` indicating a failed step always fails the overall pipeline. A value of `ignore` indicates the failure is ignored. This attribute is of enumeration `Failure` and is optional.
 
+<a id="the-commands-attribute"></a>
+
 ## The `commands` attribute
 
 Defines a list of shell commands executed on the host machine. This attribute is an array of type `string` and is required.
+
+<a id="the-environment-attribute"></a>
 
 ## The `environment` attribute
 
 Defines a list of environment variables scoped to the pipeline step. This attribute is of type `[string, string]` and is optional.
 
+<a id="the-when-section"></a>
+
 ## The `when` section
 
 The conditions used to determine whether or not the step should be skipped. This attribute is of type [`Conditions`](#the-conditions-object) and is optional.
 
+<a id="the-depends_on-attribute"></a>
+
 ## The `depends_on` attribute
 
 Defines a list of steps dependencies, used to defer step execution until the named steps are in a completed state. This attribute is of type `string` and is optional.
+
+<a id="the-conditions-object"></a>
 
 # The `Conditions` object
 
@@ -196,41 +256,61 @@ class Conditions {
 }
 {{< / highlight >}}
 
+<a id="the-action-attribute"></a>
+
 ## The `action` attribute
 
 Defines matching criteria based on the build action. The build action is synonymous with a webhook action (non-normative). This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
+
+<a id="the-branch-attribute"></a>
 
 ## The `branch` attribute
 
 Defines matching criteria based on the git branch. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
 
+<a id="the-cron-attribute"></a>
+
 ## The `cron` attribute
 
 Defines matching criteria based on the cron job that triggered the build. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
+
+<a id="the-event-attribute"></a>
 
 ## The `event` attribute
 
 Defines matching criteria based on the build event. The build event is synonymous with a webhook event (non-normative). This attribute is of type [`Constraint`](#the-constraint-object) or an array of type [`Event`](#the-event-enum) and is optional.
 
+<a id="the-instance-attribute"></a>
+
 ## The `instance` attribute
 
 Defines matching criteria based on the instance hostname. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
+
+<a id="the-ref-attribute"></a>
 
 ## The `ref` attribute
 
 Defines matching criteria based on the git reference. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
 
+<a id="the-repo-attribute"></a>
+
 ## The `repo` attribute
 
 Defines matching criteria based on the repository name. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
+
+<a id="the-status-attribute"></a>
 
 ## The `status` attribute
 
 Defines matching criteria based on the pipeline status. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type [`Status`](#the-status-enum) and is optional.
 
+<a id="the-target-attribute"></a>
+
 ## The `target` attribute
 
 Defines matching criteria based on the target environment. The target environment is typically defined by a promote or rollback event (non-normative). This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
+
+<a id="the-constraint-object"></a>
 
 # The `Constraint` object
 
@@ -243,13 +323,19 @@ class Constraint {
 }
 {{< / highlight >}}
 
+<a id="the-include-attribute"></a>
+
 ## The `include` attribute
 
 List of matching patterns. If no pattern is a match, the parent object is skipped. This attribute is an array of type `string` and is optional.
 
+<a id="the-exclude-attribute"></a>
+
 ## The `exclude` attribute
 
 List of matching patterns. If any pattern is a match, the parent object is skipped. This attribute is an array of type `string` and is optional.
+
+<a id="the-concurrency-object"></a>
 
 # The `Concurrency` object
 
@@ -260,6 +346,8 @@ class Concurrency {
   limit: number;
 }
 {{< / highlight >}}
+
+<a id="the-workspace-object"></a>
 
 # The `Workspace` object
 
@@ -272,6 +360,8 @@ class Workspace {
 {{< / highlight >}}
 
 # Enums
+
+<a id="the-event-enum"></a>
 
 ## The `Event` enum
 
@@ -289,6 +379,8 @@ enum Event {
 }
 {{< / highlight >}}
 
+<a id="the-status-enum"></a>
+
 ## The `Status` enum
 
 The `Status` enum provides a list of pipeline statuses. The default pipeline state is `success`, even if the pipeline is still running.
@@ -300,6 +392,8 @@ enum Status {
 }
 {{< / highlight >}}
 
+<a id="the-failure-enum"></a>
+
 ## The `Failure` enum
 
 The `Failure` enum defines a list of failure behaviors. The value `always` indicates a failure will fail the parent process. The value `ignore` indicates the failure is silently ignored.
@@ -310,6 +404,8 @@ enum Failure {
   ignore,
 }
 {{< / highlight >}}
+
+<a id="the-os-enum"></a>
 
 ## The `OS` enum
 
@@ -327,6 +423,8 @@ enum OS {
   windows,
 }
 {{< / highlight >}}
+
+<a id="the-arch-enum"></a>
 
 ## The `Arch` enum
 

--- a/content/yaml/exec.md
+++ b/content/yaml/exec.md
@@ -18,7 +18,7 @@ This document introduces the data structures that represent the _exec pipeline_.
 
 The [`Resource`](#the-resource-interface) interface is implemented by all top-level objects, including the exec [`Pipeline`](#the-pipeline-object).
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 interface Resource {
   kind: string;
   type: string;
@@ -26,7 +26,7 @@ interface Resource {
   concurrency: Concurrency;
   depends_on: string[];
 }
-{{< / highlight >}}
+```
 
 <a id="the-kind-attribute"></a>
 
@@ -64,7 +64,7 @@ Defines a list of pipeline dependencies, used to defer execution of the pipeline
 
 The [`Pipeline`](#the-pipeline-object) is the top-level object used to represent the exec pipeline. The [`Pipeline`](#the-pipeline-object) object implements the [`Resource`](#the-resource-interface) interface.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Pipeline : Resource {
   kind:      string;
   type:      string;
@@ -75,7 +75,7 @@ class Pipeline : Resource {
   steps:     Step[];
   trigger:   Conditions;
 }
-{{< / highlight >}}
+```
 
 <a id="the-kind-attribute"></a>
 
@@ -125,14 +125,14 @@ The conditions used to determine whether or not the pipeline should be skipped. 
 
 The [`Platform`](#the-platform-object) object defines the target os and architecture for the pipeline and is used to route the pipeline to the correct instance (non-normative).
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Platform {
   os:      OS;
   arch:    Arch;
   variant: string;
   version: string;
 }
-{{< / highlight >}}
+```
 
 <a id="the-os-attribute"></a>
 
@@ -164,12 +164,12 @@ Defines the operating system version. This is most commonly used in conjunction 
 
 The [`Clone`](#the-clone-object) object defines the clone behavior for the pipeline.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Clone {
   depth:   number;
   disable: boolean;
 }
-{{< / highlight >}}
+```
 
 <a id="the-depth-attribute"></a>
 
@@ -189,7 +189,7 @@ Disables cloning the repository. This is an optional `boolean` value. It can be 
 
 The `Step` object defines a pipeline step.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Step {
   name:        string;
   failure:     Failure;
@@ -198,7 +198,7 @@ class Step {
   when:        Conditions;
   depends_on:  string[];
 }
-{{< / highlight >}}
+```
 
 <a id="the-name-attribute"></a>
 
@@ -242,7 +242,7 @@ Defines a list of steps dependencies, used to defer step execution until the nam
 
 The [`Conditions`](#the-conditions-object) object defines a set of conditions. If any condition evaluates to true its parent object is skipped.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Conditions {
   action:   Constraint | string[];
   branch:   Constraint | string[];
@@ -254,7 +254,7 @@ class Conditions {
   status:   Constraint | Status[];
   target:   Constraint | string[];
 }
-{{< / highlight >}}
+```
 
 <a id="the-action-attribute"></a>
 
@@ -316,12 +316,12 @@ Defines matching criteria based on the target environment. The target environmen
 
 The [`Constraint`](#the-constraint-object) object defines pattern matching criteria. If the pattern matching evaluates to false, the parent object is skipped.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Constraint {
   exclude: string[];
   include: string[];
 }
-{{< / highlight >}}
+```
 
 <a id="the-include-attribute"></a>
 
@@ -341,11 +341,11 @@ List of matching patterns. If any pattern is a match, the parent object is skipp
 
 The [`Concurrency`](#the-concurrency-object) object defines the concurrency limits for the named pipeline.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Concurrency {
   limit: number;
 }
-{{< / highlight >}}
+```
 
 <a id="the-workspace-object"></a>
 
@@ -353,11 +353,11 @@ class Concurrency {
 
 The [`Workspace`](#the-workspace-object) object defines the path to which the source code is cloned (non-normative) and the default working directory for each pipeline step (non-normative).
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Workspace {
   path: string;
 }
-{{< / highlight >}}
+```
 
 # Enums
 
@@ -367,7 +367,7 @@ class Workspace {
 
 The `Event` enum provides a list of pipeline events. This value represents the event that triggered the pipeline.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum Event {
   cron,
   custom,
@@ -377,7 +377,7 @@ enum Event {
   rollback,
   tag,
 }
-{{< / highlight >}}
+```
 
 <a id="the-status-enum"></a>
 
@@ -385,12 +385,12 @@ enum Event {
 
 The `Status` enum provides a list of pipeline statuses. The default pipeline state is `success`, even if the pipeline is still running.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum Status {
   failure,
   success,
 }
-{{< / highlight >}}
+```
 
 <a id="the-failure-enum"></a>
 
@@ -398,12 +398,12 @@ enum Status {
 
 The `Failure` enum defines a list of failure behaviors. The value `always` indicates a failure will fail the parent process. The value `ignore` indicates the failure is silently ignored.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum Failure {
   always,
   ignore,
 }
-{{< / highlight >}}
+```
 
 <a id="the-os-enum"></a>
 
@@ -411,7 +411,7 @@ enum Failure {
 
 The `OS` enum provides a list of supported operating systems.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum OS {
   darwin,
   dragonfly,
@@ -422,7 +422,7 @@ enum OS {
   solaris,
   windows,
 }
-{{< / highlight >}}
+```
 
 <a id="the-arch-enum"></a>
 
@@ -430,11 +430,11 @@ enum OS {
 
 The `Arch` enum provides a list of supported chip architectures.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum Arch {
   386,
   amd64,
   arm64,
   arm,
 }
-{{< / highlight >}}
+```

--- a/content/yaml/exec.md
+++ b/content/yaml/exec.md
@@ -5,8 +5,6 @@ title_in_card: Exec Pipeline Specification
 author: bradrydzewski
 weight: 4
 toc: true
-type: spec
-hidden: true
 
 description: |
   Exec pipeline specification document.

--- a/content/yaml/exec.md
+++ b/content/yaml/exec.md
@@ -5,6 +5,7 @@ title_in_card: Exec Pipeline Specification
 author: bradrydzewski
 weight: 4
 toc: true
+type: spec
 
 description: |
   Exec pipeline specification document.

--- a/content/yaml/kubernetes.md
+++ b/content/yaml/kubernetes.md
@@ -18,7 +18,7 @@ This document introduces the data structures that represent the _kubernetes pipe
 
 The [`Resource`](#the-resource-interface) interface is implemented by all top-level objects, including the kubernetes [`Pipeline`](#the-pipeline-object).
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 interface Resource {
   kind: string;
   type: string;
@@ -26,7 +26,7 @@ interface Resource {
   concurrency: Concurrency;
   depends_on: string[];
 }
-{{< / highlight >}}
+```
 
 <a id="the-kind-attribute"></a>
 
@@ -64,7 +64,7 @@ Defines a list of pipeline dependencies, used to defer execution of the pipeline
 
 The [`Pipeline`](#the-pipeline-object) is the top-level object used to represent the kubernetes pipeline. The [`Pipeline`](#the-pipeline-object) object implements the [`Resource`](#the-resource-interface) interface.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Pipeline : Resource {
   kind:      string;
   type:      string;
@@ -79,7 +79,7 @@ class Pipeline : Resource {
 
   image_pull_secrets: string[]
 }
-{{< / highlight >}}
+```
 
 <a id="the-kind-attribute"></a>
 
@@ -141,14 +141,14 @@ The list of secrets used to pull private Docker images; This attribute is an arr
 
 The [`Platform`](#the-platform-object) object defines the target os and architecture for the pipeline.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Platform {
   os:      OS;
   arch:    Arch;
   variant: string;
   version: string;
 }
-{{< / highlight >}}
+```
 
 <a id="the-os-attribute"></a>
 
@@ -180,12 +180,12 @@ Defines the operating system version. This is most commonly used in conjunction 
 
 The [`Clone`](#the-clone-object) object defines the clone behavior for the pipeline.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Clone {
   depth:   number;
   disable: boolean;
 }
-{{< / highlight >}}
+```
 
 <a id="the-depth-attribute"></a>
 
@@ -205,7 +205,7 @@ Disables cloning the repository. This is an optional `boolean` value. It can be 
 
 The `Step` object defines a pipeline step.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Step {
   command:     string[];
   commands:    string[];
@@ -222,7 +222,7 @@ class Step {
   when:        Conditions;
   depends_on:  string[]
 }
-{{< / highlight >}}
+```
 
 <a id="the-commands-attribute"></a>
 
@@ -308,7 +308,7 @@ Defines a list of steps dependencies, used to defer step execution until the nam
 
 The [`Conditions`](#the-conditions-object) object defines a set of conditions. If any condition evaluates to true its parent object is skipped.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Conditions {
   action:   Constraint | string[];
   branch:   Constraint | string[];
@@ -320,7 +320,7 @@ class Conditions {
   status:   Constraint | Status[];
   target:   Constraint | string[];
 }
-{{< / highlight >}}
+```
 
 <a id="the-action-attribute"></a>
 
@@ -382,12 +382,12 @@ Defines matching criteria based on the target environment. The target environmen
 
 The [`Constraint`](#the-constraint-object) object defines pattern matching criteria. If the pattern matching evaluates to false, the parent object is skipped.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Constraint {
   exclude: string[];
   include: string[];
 }
-{{< / highlight >}}
+```
 
 <a id="the-include-attribute"></a>
 
@@ -407,11 +407,11 @@ List of matching patterns. If any pattern is a match, the parent object is skipp
 
 The [`Secret`](#the-secret-object) defines the named source of a secret.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Secret {
   from_secret: string;
 }
-{{< / highlight >}}
+```
 
 <a id="the-concurrency-object"></a>
 
@@ -419,11 +419,11 @@ class Secret {
 
 The [`Concurrency`](#the-concurrency-object) object defines the concurrency limits for the named pipeline.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Concurrency {
   limit: number;
 }
-{{< / highlight >}}
+```
 
 <a id="the-workspace-object"></a>
 
@@ -431,11 +431,11 @@ class Concurrency {
 
 The [`Workspace`](#the-workspace-object) object defines the path to which the source code is cloned (non-normative) and the default working directory for each pipeline step (non-normative).
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Workspace {
   path: string;
 }
-{{< / highlight >}}
+```
 
 # Enums
 
@@ -445,7 +445,7 @@ class Workspace {
 
 The `Event` enum provides a list of pipeline events. This value represents the event that triggered the pipeline.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum Event {
   cron,
   promote,
@@ -454,7 +454,7 @@ enum Event {
   rollback,
   tag,
 }
-{{< / highlight >}}
+```
 
 <a id="the-status-enum"></a>
 
@@ -462,12 +462,12 @@ enum Event {
 
 The `Status` enum provides a list of pipeline statuses. The default pipeline state is `success`, even if the pipeline is still running.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum Status {
   failure,
   success,
 }
-{{< / highlight >}}
+```
 
 <a id="the-pull-enum"></a>
 
@@ -475,13 +475,13 @@ enum Status {
 
 The `Pull` enum defines if and when a Docker image should be pull from the registry.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum Pull {
   always,
   never,
   if-not-exists,
 }
-{{< / highlight >}}
+```
 
 <a id="the-failure-enum"></a>
 
@@ -489,12 +489,12 @@ enum Pull {
 
 The `Failure` enum defines a list of failure behaviors. The value `always` indicates a failure will fail the parent process. The value `ignore` indicates the failure is silently ignored.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum Failure {
   always,
   ignore,
 }
-{{< / highlight >}}
+```
 
 <a id="the-os-enum"></a>
 
@@ -502,7 +502,7 @@ enum Failure {
 
 The `OS` enum provides a list of supported operating systems.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum OS {
   darwin,
   dragonfly,
@@ -513,7 +513,7 @@ enum OS {
   solaris,
   windows,
 }
-{{< / highlight >}}
+```
 
 <a id="the-arch-enum"></a>
 
@@ -521,11 +521,11 @@ enum OS {
 
 The `Arch` enum provides a list of supported chip architectures.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum Arch {
   386,
   amd64,
   arm64,
   arm,
 }
-{{< / highlight >}}
+```

--- a/content/yaml/kubernetes.md
+++ b/content/yaml/kubernetes.md
@@ -5,6 +5,7 @@ title_in_card: Kubernetes Pipeline Specification
 author: bradrydzewski
 weight: 4
 toc: true
+type: spec
 
 description: |
   Kubernetes pipeline specification document.

--- a/content/yaml/kubernetes.md
+++ b/content/yaml/kubernetes.md
@@ -5,8 +5,6 @@ title_in_card: Kubernetes Pipeline Specification
 author: bradrydzewski
 weight: 4
 toc: true
-type: spec
-hidden: true
 
 description: |
   Kubernetes pipeline specification document.

--- a/content/yaml/kubernetes.md
+++ b/content/yaml/kubernetes.md
@@ -12,6 +12,8 @@ description: |
 
 This document introduces the data structures that represent the _kubernetes pipeline_. The Kubernetes pipeline is a continuous integration pipeline that executes pipeline steps as containers inside Kubernetes Pods.
 
+<a id="the-resource-interface"></a>
+
 # The `Resource` interface
 
 The [`Resource`](#the-resource-interface) interface is implemented by all top-level objects, including the kubernetes [`Pipeline`](#the-pipeline-object).
@@ -26,25 +28,37 @@ interface Resource {
 }
 {{< / highlight >}}
 
+<a id="the-kind-attribute"></a>
+
 ## The `kind` attribute
 
 Defines the kind of resource, used to identify the resource implementation. This attribute is of type `string` and is required.
+
+<a id="the-type-attribute"></a>
 
 ## The `type` attribute
 
 Defines the type of resource, used to identify the resource implementation. This attribute is of type `string` and is required.
 
+<a id="the-name-attribute"></a>
+
 ## The `name` attribute
 
 The name of the resource. This value is required and must match `[a-zA-Z0-9_-]`. This value is displayed in the user interface (non-normative) and is used to identify the pipeline (non-normative).
+
+<a id="the-concurrency-attribute"></a>
 
 ## The `concurrency` attribute
 
 Defines the concurrency limits for the pipeline stage. This attribute is of type [`Concurrency`](#the-concurrency-object) and is optional.
 
+<a id="the-depends_on-attribute"></a>
+
 ## The `depends_on` attribute
 
 Defines a list of pipeline dependencies, used to defer execution of the pipeline until the named pipelines are in a completed state. This attribute is an array of type `string` and is optional.
+
+<a id="the-pipeline-object"></a>
 
 # The `Pipeline` object
 
@@ -67,41 +81,61 @@ class Pipeline : Resource {
 }
 {{< / highlight >}}
 
+<a id="the-kind-attribute"></a>
+
 ## The `kind` attribute
 
 The kind of resource. This value must be set to `pipeline`.
+
+<a id="the-type-attribute"></a>
 
 ## The `type` attribute
 
 The type of resource. This value must be set to `kubernetes`.
 
+<a id="the-platform-section"></a>
+
 ## The `platform` section
 
 The target operating system and architecture on which the pipeline must execute. This attribute is of type [`Platform`](#the-platform-object) and is recommended. If empty, the default operating system and architecture may be `linux` and `amd64` respectively.
+
+<a id="the-workspace-section"></a>
 
 ## The `workspace` section
 
 The working directory where the source code is cloned and the default working directory for each pipeline step. This attribute is of type [`Workspace`](#the-workspace-object) and is optional.
 
+<a id="the-clone-section"></a>
+
 ## The `clone` section
 
 Defines the pipeline clone behavior and can be used to disable automatic cloning. This attribute is of type [`Clone`](#the-clone-object) and is optional.
+
+<a id="the-steps-section"></a>
 
 ## The `steps` section
 
 Defines the pipeline steps. This attribute is an array of type [`Step`](#the-step-object) and is required. The array must not be empty and the order of the array must be retained.
 
+<a id="the-node-attribute"></a>
+
 ## The `node` attribute
 
 Defines key value pairs used to route the pipeline to a specific runner or group of runners. This attribute is of type `[string, string]` and is optional.
+
+<a id="the-trigger-section"></a>
 
 ## The `trigger` section
 
 The conditions used to determine whether or not the pipeline should be skipped. This attribute is of type [`Conditions`](#the-conditions-object) and is optional.
 
+<a id="the-image_pull_secrets-attribute"></a>
+
 ## The `image_pull_secrets` attribute
 
 The list of secrets used to pull private Docker images; This attribute is an array of type `string` and is optional.
+
+<a id="the-platform-object"></a>
 
 # The `Platform` object
 
@@ -116,21 +150,31 @@ class Platform {
 }
 {{< / highlight >}}
 
+<a id="the-os-attribute"></a>
+
 ## The `os` attribute
 
 Defines the target operating system. The attribute is an enumeration of type `OS` and is recommended. If empty the operating system may default to Linux.
+
+<a id="the-arch-attribute"></a>
 
 ## The `arch` attribute
 
 Defines the target architecture. The attribute is an enumeration of type `Arch` and is recommended. If empty the architecture may default to amd64.
 
+<a id="the-variant-attribute"></a>
+
 ## The `variant` attribute
 
 Defines the architecture variant. This is most commonly used in conjunction with the arm architecture (non-normative) and can be used to differentiate between armv7, armv8, and so on (non-normative).
 
+<a id="the-version-attribute"></a>
+
 ## The `version` attribute
 
 Defines the operating system version. This is most commonly used in conjunction with the windows operating system (non-normative) and can be used to differentiate between 1809, 1903, and so on (non-normative).
+
+<a id="the-clone-object"></a>
 
 # The `Clone` object
 
@@ -143,13 +187,19 @@ class Clone {
 }
 {{< / highlight >}}
 
+<a id="the-depth-attribute"></a>
+
 ## The `depth` attribute
 
 Configures the clone depth. This is an optional `number` value. If empty the full repository may be cloned (non-normative).
 
+<a id="the-disable-attribute"></a>
+
 ## The `disable` attribute
 
 Disables cloning the repository. This is an optional `boolean` value. It can be useful when you need to disable implement your own custom clone logic (non-normative).
+
+<a id="the-step-object"></a>
 
 # The `Step` object
 
@@ -174,58 +224,85 @@ class Step {
 }
 {{< / highlight >}}
 
+<a id="the-commands-attribute"></a>
 
 ## The `commands` attribute
 
 Defines a list of shell commands executed inside the Docker container. The commands are executed using the default container shell (non-normative) as the container `ENTRYPOINT`. This attribute is an array of type `string` and is required.
 
+<a id="the-command-attribute"></a>
+
 ## The `command` attribute
 
 Overrides the image `COMMAND`. This should only be used with service containers and cannot not be used with the `commands` attribute. This attribute is an array of type `[string]` and is optional.
+
+<a id="the-detach-attribute"></a>
 
 ## The `detach` attribute
 
 The detach attribute instructions the system to start the Docker container and then run in the background. This value is of type `boolean` and is optional.
 
+<a id="the-entrypoint-attribute"></a>
+
 ## The `entrypoint` attribute
 
 Overrides the image `ENTRYPOINT`. This should only be used with service containers and cannot not be used with the `commands` attribute. This attribute is an array of type `[string]` and is optional.
+
+<a id="the-environment-attribute"></a>
 
 ## The `environment` attribute
 
 Defines a list of environment variables scoped to the pipeline step. This attribute is of type `[string, string | Secret]` and is optional.
 
+<a id="the-failure-attribute"></a>
+
 ## The `failure` attribute
 
 Defines how the system handles failure. The default value is `always` indicating a failed step always fails the overall pipeline. A value of `ignore` indicates the failure is ignored. This attribute is of enumeration [`Failure`](#the-failure-enum) and is optional.
+
+<a id="the-image-attribute"></a>
 
 ## The `image` attribute
 
 The name of the Docker image. The image name should include the tag and will default to the latest tag if unspecified. This value is of type `string` and is required.
 
+<a id="the-name-attribute"></a>
+
 ## The `name` attribute
 
 The name of the step. This value is required and must match [a-zA-Z0-9_-]. This value is displayed in the user interface (non-normative) and is used to identify the step (non-normative).
+
+<a id="the-privileged-attribute"></a>
 
 ## The `privileged` attribute
 
 Overrides the default Docker security policy and grants the container nearly full access to the host machine. This attribute is of type `boolean` and is optional.
 
+<a id="the-pull-attribute"></a>
+
 ## The `pull` attribute
 
 Defines how and when the system should pull images. This attribute is of enumeration [`Pull`](#the-pull-enum) and is optional.
+
+<a id="the-user-attribute"></a>
 
 ## The `user` attribute
 
 Overrides the default username or uid used when executing the pipeline commands or entrypoint. This attribute is of type `string` and is optional.
 
+<a id="the-when-section"></a>
+
 ## The `when` section
 
 The conditions used to determine whether or not the step should be skipped. This attribute is of type [`Conditions`](#the-conditions-object) and is optional.
 
+<a id="the-depends_on-attribute"></a>
+
 ## The `depends_on` attribute
 
 Defines a list of steps dependencies, used to defer step execution until the named steps are in a completed state. This attribute is of type `string` and is optional.
+
+<a id="the-conditions-object"></a>
 
 # The `Conditions` object
 
@@ -245,41 +322,61 @@ class Conditions {
 }
 {{< / highlight >}}
 
+<a id="the-action-attribute"></a>
+
 ## The `action` attribute
 
 Defines matching criteria based on the build action. The build action is synonymous with a webhook action (non-normative). This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
+
+<a id="the-branch-attribute"></a>
 
 ## The `branch` attribute
 
 Defines matching criteria based on the git branch. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
 
+<a id="the-cron-attribute"></a>
+
 ## The `cron` attribute
 
 Defines matching criteria based on the cron job that triggered the build. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
+
+<a id="the-event-attribute"></a>
 
 ## The `event` attribute
 
 Defines matching criteria based on the build event. The build event is synonymous with a webhook event (non-normative). This attribute is of type [`Constraint`](#the-constraint-object) or an array of type [`Event`](#the-event-enum) and is optional.
 
+<a id="the-instance-attribute"></a>
+
 ## The `instance` attribute
 
 Defines matching criteria based on the instance hostname. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
+
+<a id="the-ref-attribute"></a>
 
 ## The `ref` attribute
 
 Defines matching criteria based on the git reference. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
 
+<a id="the-repo-attribute"></a>
+
 ## The `repo` attribute
 
 Defines matching criteria based on the repository name. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
+
+<a id="the-status-attribute"></a>
 
 ## The `status` attribute
 
 Defines matching criteria based on the pipeline status. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type [`Status`](#the-status-enum) and is optional.
 
+<a id="the-target-attribute"></a>
+
 ## The `target` attribute
 
 Defines matching criteria based on the target environment. The target environment is typically defined by a promote or rollback event (non-normative). This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
+
+<a id="the-constraint-object"></a>
 
 # The `Constraint` object
 
@@ -292,13 +389,19 @@ class Constraint {
 }
 {{< / highlight >}}
 
+<a id="the-include-attribute"></a>
+
 ## The `include` attribute
 
 List of matching patterns. If no pattern is a match, the parent object is skipped. This attribute is an array of type `string` and is optional.
 
+<a id="the-exclude-attribute"></a>
+
 ## The `exclude` attribute
 
 List of matching patterns. If any pattern is a match, the parent object is skipped. This attribute is an array of type `string` and is optional.
+
+<a id="the-secret-object"></a>
 
 # The `Secret` object
 
@@ -310,6 +413,8 @@ class Secret {
 }
 {{< / highlight >}}
 
+<a id="the-concurrency-object"></a>
+
 # The `Concurrency` object
 
 The [`Concurrency`](#the-concurrency-object) object defines the concurrency limits for the named pipeline.
@@ -319,6 +424,8 @@ class Concurrency {
   limit: number;
 }
 {{< / highlight >}}
+
+<a id="the-workspace-object"></a>
 
 # The `Workspace` object
 
@@ -331,6 +438,8 @@ class Workspace {
 {{< / highlight >}}
 
 # Enums
+
+<a id="the-event-enum"></a>
 
 ## The `Event` enum
 
@@ -347,6 +456,8 @@ enum Event {
 }
 {{< / highlight >}}
 
+<a id="the-status-enum"></a>
+
 ## The `Status` enum
 
 The `Status` enum provides a list of pipeline statuses. The default pipeline state is `success`, even if the pipeline is still running.
@@ -357,6 +468,8 @@ enum Status {
   success,
 }
 {{< / highlight >}}
+
+<a id="the-pull-enum"></a>
 
 ## The `Pull` enum
 
@@ -370,6 +483,8 @@ enum Pull {
 }
 {{< / highlight >}}
 
+<a id="the-failure-enum"></a>
+
 ## The `Failure` enum
 
 The `Failure` enum defines a list of failure behaviors. The value `always` indicates a failure will fail the parent process. The value `ignore` indicates the failure is silently ignored.
@@ -380,6 +495,8 @@ enum Failure {
   ignore,
 }
 {{< / highlight >}}
+
+<a id="the-os-enum"></a>
 
 ## The `OS` enum
 
@@ -397,6 +514,8 @@ enum OS {
   windows,
 }
 {{< / highlight >}}
+
+<a id="the-arch-enum"></a>
 
 ## The `Arch` enum
 

--- a/content/yaml/ssh.md
+++ b/content/yaml/ssh.md
@@ -5,6 +5,7 @@ title_in_card: SSH Pipeline Specification
 author: bradrydzewski
 weight: 4
 toc: true
+type: spec
 
 description: |
   SSH pipeline specification document.

--- a/content/yaml/ssh.md
+++ b/content/yaml/ssh.md
@@ -5,8 +5,6 @@ title_in_card: SSH Pipeline Specification
 author: bradrydzewski
 weight: 4
 toc: true
-type: spec
-hidden: true
 
 description: |
   SSH pipeline specification document.

--- a/content/yaml/ssh.md
+++ b/content/yaml/ssh.md
@@ -10,7 +10,9 @@ description: |
   SSH pipeline specification document.
 ---
 
-This document introduces the data structures that represent the _ssh pipeline_. The ssh pipeline is a continuous integration pipeline that executes workloads on remote servers using the ssh protocol. 
+This document introduces the data structures that represent the _ssh pipeline_. The ssh pipeline is a continuous integration pipeline that executes workloads on remote servers using the ssh protocol.
+
+<a id="the-resource-interface"></a>
 
 # The `Resource` interface
 
@@ -26,25 +28,37 @@ interface Resource {
 }
 {{< / highlight >}}
 
+<a id="the-kind-attribute"></a>
+
 ## The `kind` attribute
 
 Defines the kind of resource, used to identify the resource implementation. This attribute is of type `string` and is required.
+
+<a id="the-type-attribute"></a>
 
 ## The `type` attribute
 
 Defines the type of resource, used to identify the resource implementation. This attribute is of type `string` and is required.
 
+<a id="the-name-attribute"></a>
+
 ## The `name` attribute
 
 The name of the resource. This value is required and must match `[a-zA-Z0-9_-]`. This value is displayed in the user interface (non-normative) and is used to identify the pipeline (non-normative).
+
+<a id="the-concurrency-attribute"></a>
 
 ## The `concurrency` attribute
 
 Defines the concurrency limits for the pipeline stage. This attribute is of type [`Concurrency`](#the-concurrency-object) and is optional.
 
+<a id="the-depends_on-attribute"></a>
+
 ## The `depends_on` attribute
 
 Defines a list of pipeline dependencies, used to defer execution of the pipeline until the named pipelines are in a completed state. This attribute is an array of type `string` and is optional.
+
+<a id="the-pipeline-object"></a>
 
 # The `Pipeline` object
 
@@ -64,37 +78,55 @@ class Pipeline : Resource {
 }
 {{< / highlight >}}
 
+<a id="the-kind-attribute"></a>
+
 ## The `kind` attribute
 
 The kind of resource. This value must be set to `pipeline`.
+
+<a id="the-type-attribute"></a>
 
 ## The `type` attribute
 
 The type of resource. This value must be set to `ssh`.
 
+<a id="the-server-section"></a>
+
 ## The `server` section
 
 The remote server address and authentication credentials. This attribute is of type [`Server`](#the-server-object) and is required.
+
+<a id="the-platform-section"></a>
 
 ## The `platform` section
 
 The target operating system and architecture on which the pipeline must execute. This attribute is of type [`Platform`](#the-platform-object) and is recommended. If empty, the default operating system and architecture may be `linux` and `amd64` respectively.
 
+<a id="the-workspace-section"></a>
+
 ## The `workspace` section
 
 The working directory where the source code is cloned and the default working directory for each pipeline step. This attribute is of type [`Workspace`](#the-workspace-object) and is optional.
+
+<a id="the-clone-section"></a>
 
 ## The `clone` section
 
 Defines the pipeline clone behavior and can be used to disable automatic cloning. This attribute is of type [`Clone`](#the-clone-object) and is optional.
 
+<a id="the-steps-section"></a>
+
 ## The `steps` section
 
 Defines the pipeline steps. This attribute is an array of type [`Step`](#the-step-object) and is required. The array must not be empty and the order of the array must be retained.
 
+<a id="the-trigger-section"></a>
+
 ## The `trigger` section
 
 The conditions used to determine whether or not the pipeline should be skipped. This attribute is of type [`Conditions`](#the-conditions-object) and is optional.
+
+<a id="the-server-object"></a>
 
 # The `Server` object
 
@@ -109,21 +141,31 @@ class Clone {
 }
 {{< / highlight >}}
 
+<a id="the-host-attribute"></a>
+
 ## The `host` attribute
 
 Configures the server host address. The host address may include the port number. This is a required `string` or [`Secret`](#the-secret-object) value.
+
+<a id="the-user-attribute"></a>
 
 ## The `user` attribute
 
 Configures the username used to authenticate with the server. This is a required `string` or [`Secret`](#the-secret-object) value.
 
+<a id="the-password-attribute"></a>
+
 ## The `password` attribute
 
 Configures the password used to authenticate with the server. This is an optional `string` or [`Secret`](#the-secret-object) value.
 
+<a id="the-ssh_key-attribute"></a>
+
 ## The `ssh_key` attribute
 
 Configures the ssh key used to authenticate with the server. This is an optional `string` or [`Secret`](#the-secret-object) value.
+
+<a id="the-platform-object"></a>
 
 # The `Platform` object
 
@@ -138,21 +180,31 @@ class Platform {
 }
 {{< / highlight >}}
 
+<a id="the-os-attribute"></a>
+
 ## The `os` attribute
 
 Defines the target operating system. The attribute is an enumeration of type `OS` and is recommended. If empty the operating system may default to Linux.
+
+<a id="the-arch-attribute"></a>
 
 ## The `arch` attribute
 
 Defines the target architecture. The attribute is an enumeration of type `Arch` and is recommended. If empty the architecture may default to amd64.
 
+<a id="the-variant-attribute"></a>
+
 ## The `variant` attribute
 
 Defines the architecture variant. This is most commonly used in conjunction with the arm architecture (non-normative) and can be used to differentiate between armv7, armv8, and so on (non-normative).
 
+<a id="the-version-attribute"></a>
+
 ## The `version` attribute
 
 Defines the operating system version. This is most commonly used in conjunction with the windows operating system (non-normative) and can be used to differentiate between 1809, 1903, and so on (non-normative).
+
+<a id="the-clone-object"></a>
 
 # The `Clone` object
 
@@ -165,13 +217,19 @@ class Clone {
 }
 {{< / highlight >}}
 
+<a id="the-depth-attribute"></a>
+
 ## The `depth` attribute
 
 Configures the clone depth. This is an optional `number` value. If empty the full repository may be cloned (non-normative).
 
+<a id="the-disable-attribute"></a>
+
 ## The `disable` attribute
 
 Disables cloning the repository. This is an optional `boolean` value. It can be useful when you need to disable implement your own custom clone logic (non-normative).
+
+<a id="the-step-object"></a>
 
 # The `Step` object
 
@@ -188,29 +246,43 @@ class Step {
 }
 {{< / highlight >}}
 
+<a id="the-name-attribute"></a>
+
 ## The `name` attribute
 
-The name of the step. This value is required and must match [a-zA-Z0-9_-]. This value is displayed in the user interface (non-normative) and is used to identify the step (non-normative). 
+The name of the step. This value is required and must match [a-zA-Z0-9_-]. This value is displayed in the user interface (non-normative) and is used to identify the step (non-normative).
+
+<a id="the-failure-attribute"></a>
 
 ## The `failure` attribute
 
 Defines how the system handles failure. The default value is `always` indicating a failed step always fails the overall pipeline. A value of `ignore` indicates the failure is ignored. This attribute is of enumeration [`Failure`](#the-failure-enum) and is optional.
 
+<a id="the-commands-attribute"></a>
+
 ## The `commands` attribute
 
 Defines a list of shell commands executed on the host machine. This attribute is an array of type `string` and is required.
+
+<a id="the-environment-attribute"></a>
 
 ## The `environment` attribute
 
 Defines a list of environment variables scoped to the pipeline step. This attribute is of type `[string, string]` and is optional.
 
+<a id="the-when-section"></a>
+
 ## The `when` section
 
 The conditions used to determine whether or not the step should be skipped. This attribute is of type [`Conditions`](#the-conditions-object) and is optional.
 
+<a id="the-depends_on-attribute"></a>
+
 ## The `depends_on` attribute
 
 Defines a list of steps dependencies, used to defer step execution until the named steps are in a completed state. This attribute is of type `string` and is optional.
+
+<a id="the-conditions-object"></a>
 
 # The `Conditions` object
 
@@ -230,41 +302,61 @@ class Conditions {
 }
 {{< / highlight >}}
 
+<a id="the-action-attribute"></a>
+
 ## The `action` attribute
 
 Defines matching criteria based on the build action. The build action is synonymous with a webhook action (non-normative). This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
+
+<a id="the-branch-attribute"></a>
 
 ## The `branch` attribute
 
 Defines matching criteria based on the git branch. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
 
+<a id="the-cron-attribute"></a>
+
 ## The `cron` attribute
 
 Defines matching criteria based on the cron job that triggered the build. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
+
+<a id="the-event-attribute"></a>
 
 ## The `event` attribute
 
 Defines matching criteria based on the build event. The build event is synonymous with a webhook event (non-normative). This attribute is of type [`Constraint`](#the-constraint-object) or an array of type [`Event`](#the-event-enum) and is optional.
 
+<a id="the-instance-attribute"></a>
+
 ## The `instance` attribute
 
 Defines matching criteria based on the instance hostname. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
+
+<a id="the-ref-attribute"></a>
 
 ## The `ref` attribute
 
 Defines matching criteria based on the git reference. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
 
+<a id="the-repo-attribute"></a>
+
 ## The `repo` attribute
 
 Defines matching criteria based on the repository name. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
+
+<a id="the-status-attribute"></a>
 
 ## The `status` attribute
 
 Defines matching criteria based on the pipeline status. This attribute is of type [`Constraint`](#the-constraint-object) or an array of type [`Status`](#the-status-enum) and is optional.
 
+<a id="the-target-attribute"></a>
+
 ## The `target` attribute
 
 Defines matching criteria based on the target environment. The target environment is typically defined by a promote or rollback event (non-normative). This attribute is of type [`Constraint`](#the-constraint-object) or an array of type `string` and is optional.
+
+<a id="the-constraint-object"></a>
 
 # The `Constraint` object
 
@@ -277,13 +369,19 @@ class Constraint {
 }
 {{< / highlight >}}
 
+<a id="the-include-attribute"></a>
+
 ## The `include` attribute
 
 List of matching patterns. If no pattern is a match, the parent object is skipped. This attribute is an array of type `string` and is optional.
 
+<a id="the-exclude-attribute"></a>
+
 ## The `exclude` attribute
 
 List of matching patterns. If any pattern is a match, the parent object is skipped. This attribute is an array of type `string` and is optional.
+
+<a id="the-secret-object"></a>
 
 # The `Secret` object
 
@@ -295,6 +393,8 @@ class Secret {
 }
 {{< / highlight >}}
 
+<a id="the-concurrency-object"></a>
+
 # The `Concurrency` object
 
 The [`Concurrency`](#the-concurrency-object) object defines the concurrency limits for the named pipeline.
@@ -304,6 +404,8 @@ class Concurrency {
   limit: number;
 }
 {{< / highlight >}}
+
+<a id="the-workspace-object"></a>
 
 # The `Workspace` object
 
@@ -316,6 +418,8 @@ class Workspace {
 {{< / highlight >}}
 
 # Enums
+
+<a id="the-event-enum"></a>
 
 ## The `Event` enum
 
@@ -333,6 +437,8 @@ enum Event {
 }
 {{< / highlight >}}
 
+<a id="the-status-enum"></a>
+
 ## The `Status` enum
 
 The `Status` enum provides a list of pipeline statuses. The default pipeline state is `success`, even if the pipeline is still running.
@@ -344,6 +450,8 @@ enum Status {
 }
 {{< / highlight >}}
 
+<a id="the-failure-enum"></a>
+
 ## The `Failure` enum
 
 The `Failure` enum defines a list of failure behaviors. The value `always` indicates a failure will fail the parent process. The value `ignore` indicates the failure is silently ignored.
@@ -354,6 +462,8 @@ enum Failure {
   ignore,
 }
 {{< / highlight >}}
+
+<a id="the-os-enum"></a>
 
 ## The `OS` enum
 
@@ -371,6 +481,8 @@ enum OS {
   windows,
 }
 {{< / highlight >}}
+
+<a id="the-arch-enum"></a>
 
 ## The `Arch` enum
 

--- a/content/yaml/ssh.md
+++ b/content/yaml/ssh.md
@@ -18,7 +18,7 @@ This document introduces the data structures that represent the _ssh pipeline_. 
 
 The [`Resource`](#the-resource-interface) interface is implemented by all top-level objects, including the ssh [`Pipeline`](#the-pipeline-object).
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 interface Resource {
   kind: string;
   type: string;
@@ -26,7 +26,7 @@ interface Resource {
   concurrency: Concurrency;
   depends_on: string[];
 }
-{{< / highlight >}}
+```
 
 <a id="the-kind-attribute"></a>
 
@@ -64,7 +64,7 @@ Defines a list of pipeline dependencies, used to defer execution of the pipeline
 
 The [`Pipeline`](#the-pipeline-object) is the top-level object used to represent the ssh pipeline. The [`Pipeline`](#the-pipeline-object) object implements the [`Resource`](#the-resource-interface) interface.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Pipeline : Resource {
   kind:      string;
   type:      string;
@@ -76,7 +76,7 @@ class Pipeline : Resource {
   steps:     Step[];
   trigger:   Conditions;
 }
-{{< / highlight >}}
+```
 
 <a id="the-kind-attribute"></a>
 
@@ -132,14 +132,14 @@ The conditions used to determine whether or not the pipeline should be skipped. 
 
 The [`Server`](#the-server-object) object defines the clone behavior for the pipeline.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Clone {
   host:    string | Secret;
   user:    string | Secret;
   password string | Secret;
   ssh_key  string | Secret;
 }
-{{< / highlight >}}
+```
 
 <a id="the-host-attribute"></a>
 
@@ -171,14 +171,14 @@ Configures the ssh key used to authenticate with the server. This is an optional
 
 The [`Platform`](#the-platform-object) object defines the target os and architecture for the pipeline.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Platform {
   os:      OS;
   arch:    Arch;
   variant: string;
   version: string;
 }
-{{< / highlight >}}
+```
 
 <a id="the-os-attribute"></a>
 
@@ -210,12 +210,12 @@ Defines the operating system version. This is most commonly used in conjunction 
 
 The [`Clone`](#the-clone-object) object defines the clone behavior for the pipeline.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Clone {
   depth:   number;
   disable: boolean;
 }
-{{< / highlight >}}
+```
 
 <a id="the-depth-attribute"></a>
 
@@ -235,7 +235,7 @@ Disables cloning the repository. This is an optional `boolean` value. It can be 
 
 The `Step` object defines a pipeline step.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Step {
   name:        string;
   failure:     Failure;
@@ -244,7 +244,7 @@ class Step {
   when:        Conditions;
   depends_on:  string[];
 }
-{{< / highlight >}}
+```
 
 <a id="the-name-attribute"></a>
 
@@ -288,7 +288,7 @@ Defines a list of steps dependencies, used to defer step execution until the nam
 
 The [`Conditions`](#the-conditions-object) object defines a set of conditions. If any condition evaluates to true its parent object is skipped.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Conditions {
   action:   Constraint | string[];
   branch:   Constraint | string[];
@@ -300,7 +300,7 @@ class Conditions {
   status:   Constraint | Status[];
   target:   Constraint | string[];
 }
-{{< / highlight >}}
+```
 
 <a id="the-action-attribute"></a>
 
@@ -362,12 +362,12 @@ Defines matching criteria based on the target environment. The target environmen
 
 The [`Constraint`](#the-constraint-object) object defines pattern matching criteria. If the pattern matching evaluates to false, the parent object is skipped.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Constraint {
   exclude: string[];
   include: string[];
 }
-{{< / highlight >}}
+```
 
 <a id="the-include-attribute"></a>
 
@@ -387,11 +387,11 @@ List of matching patterns. If any pattern is a match, the parent object is skipp
 
 The [`Secret`](#the-secret-object) defines the named source of a secret.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Secret {
   from_secret: string;
 }
-{{< / highlight >}}
+```
 
 <a id="the-concurrency-object"></a>
 
@@ -399,11 +399,11 @@ class Secret {
 
 The [`Concurrency`](#the-concurrency-object) object defines the concurrency limits for the named pipeline.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Concurrency {
   limit: number;
 }
-{{< / highlight >}}
+```
 
 <a id="the-workspace-object"></a>
 
@@ -411,11 +411,11 @@ class Concurrency {
 
 The [`Workspace`](#the-workspace-object) object defines the path to which the source code is cloned (non-normative) and the default working directory for each pipeline step (non-normative).
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 class Workspace {
   path: string;
 }
-{{< / highlight >}}
+```
 
 # Enums
 
@@ -425,7 +425,7 @@ class Workspace {
 
 The `Event` enum provides a list of pipeline events. This value represents the event that triggered the pipeline.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum Event {
   cron,
   custom,
@@ -435,7 +435,7 @@ enum Event {
   rollback,
   tag,
 }
-{{< / highlight >}}
+```
 
 <a id="the-status-enum"></a>
 
@@ -443,12 +443,12 @@ enum Event {
 
 The `Status` enum provides a list of pipeline statuses. The default pipeline state is `success`, even if the pipeline is still running.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum Status {
   failure,
   success,
 }
-{{< / highlight >}}
+```
 
 <a id="the-failure-enum"></a>
 
@@ -456,12 +456,12 @@ enum Status {
 
 The `Failure` enum defines a list of failure behaviors. The value `always` indicates a failure will fail the parent process. The value `ignore` indicates the failure is silently ignored.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum Failure {
   always,
   ignore,
 }
-{{< / highlight >}}
+```
 
 <a id="the-os-enum"></a>
 
@@ -469,7 +469,7 @@ enum Failure {
 
 The `OS` enum provides a list of supported operating systems.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum OS {
   darwin,
   dragonfly,
@@ -480,7 +480,7 @@ enum OS {
   solaris,
   windows,
 }
-{{< / highlight >}}
+```
 
 <a id="the-arch-enum"></a>
 
@@ -488,11 +488,11 @@ enum OS {
 
 The `Arch` enum provides a list of supported chip architectures.
 
-{{< highlight typescript "linenos=table" >}}
+```typescript {linenos=table}
 enum Arch {
   386,
   amd64,
   arm64,
   arm,
 }
-{{< / highlight >}}
+```

--- a/themes/default/assets/sass/partials/aside.scss
+++ b/themes/default/assets/sass/partials/aside.scss
@@ -67,18 +67,18 @@ aside #TableOfContents {
     }
     #TableOfContents ul {
         counter-reset: item;
-        padding-left: 0px !important;
     }
     #TableOfContents > ul > li {
         counter-increment: item;
         margin-bottom: 30px;
     }
     #TableOfContents > ul > li > a:before {
-        content: counters(item, ".") " ";
+        content: counters(item, ".") ".";
         display: inline-block;
-        width: 40px;
-        font-weight: 600;
-        color: #4a5568;
+        padding-right: 8px;
+        color: $gray-600;
+        line-height: $leading-snug;
+        text-decoration: none;
     }
     #TableOfContents > ul > li > ul > li {
         counter-increment: item;
@@ -86,7 +86,7 @@ aside #TableOfContents {
     #TableOfContents > ul > li > ul > li > a:before {
         content: counters(item, ".") " ";
         display: inline-block;
-        width: 40px;
+        padding-right: 8px;
     }
 }
 


### PR DESCRIPTION
# What this Pull Request does

- Remove the `hidden` declaration from the document meta information, which will allow all yaml spec documents to be displayed in the left-hand directory navigation, instead of only supporting browsing from `/yaml/`.
- Optimize the presentation of the page table of contents when the document type is spec, making it aligned and more concise.
- Completes the anchor information in the document, making it easier to quickly locate references when browsing Markdown files (rather than on a website)
- Converting Hugo Shortcode in YAML spec documents to Markdown syntax


The following are the results of the before and after comparison:

![image](https://user-images.githubusercontent.com/6902432/235509798-aa6324b3-370e-4f21-afe6-ce6a9b4489d1.png)