### PR TITLE
feat(i18n): support switching to Chinese documents

### DIFF
--- a/layouts/partials/sidebar-home.html
+++ b/layouts/partials/sidebar-home.html
@@ -7,7 +7,10 @@
 
     <nav>
         <ul>
-            <li class="sidebar-item selected"><a href="/" class="selected">Home</a></li>
+            <li class="sidebar-item selected">
+                <a href="/" class="selected" style="display: inline-block;">Home</a>
+                {{- partial "i18n-switch" . -}}
+            </li>
             <li class="category separator">Installation</li>
             <li class="sidebar-item"><a href="/server/overview">Server</a></li>
             <li class="sidebar-item"><a href="/runner/overview">Runners</a></li>  

--- a/themes/default/layouts/partials/footer.html
+++ b/themes/default/layouts/partials/footer.html
@@ -35,4 +35,7 @@
     <section>
         <p>Is there a mistake on this page? Please <a href="https://github.com/drone/docs">let us know</a> or edit <a href="https://github.com/drone/docs/blob/master/content/{{ .Page.Path }}">this page</a>.</p>
     </section>
+    <section>
+        {{- partial "i18n-footer" . -}}
+    </section>
 </footer>

--- a/themes/default/layouts/partials/i18n-footer.html
+++ b/themes/default/layouts/partials/i18n-footer.html
@@ -1,0 +1,3 @@
+<p>
+    寻找中文文档？<a href="https://drone.cool{{ .RelPermalink }}" class="href">点击此处</a> 查看中文文档。
+</p>

--- a/themes/default/layouts/partials/i18n-switch.html
+++ b/themes/default/layouts/partials/i18n-switch.html
@@ -1,0 +1,16 @@
+<a href="https://drone.cool{{ .RelPermalink }}" class="i18n-switch">中文文档</a>
+
+<style>
+    .i18n-switch{
+        float: right;
+        color: #718096 !important;
+        display: block;
+        line-height: 14px;
+        font-size: 14px;
+        font-family: Kanit;
+        font-weight: 400;
+        padding: 0px 16px;
+        position: relative;
+        text-decoration: none;
+    }
+</style>

--- a/themes/default/layouts/partials/sidebar.html
+++ b/themes/default/layouts/partials/sidebar.html
@@ -10,7 +10,8 @@
     </div> -->
 
     <nav>
-        <a href="/" class="back">Home</a>
+        <a href="/" class="back" style="display:inline-block">Home</a>
+        {{- partial "i18n-switch" . -}}
         {{ $expand := .Params.expand }}
         {{ $selected := . }}
         {{ $section := .Site.GetPage "section" .Section }}


### PR DESCRIPTION
### What this Pull Request does

Added the option to switch between Drone Chinese documents in the left navigation and Footer to support seamless switching of the current document to Chinese.

> [Drone.cool](https://drone.cool) is the Chinese version of the Drone CI documentation, and is currently updated regularly with the https://github.com/drone/docs version.

The option to switch to English documents on [Drone.cool](https://drone.cool) will be supported after this merge and after synchronization with upstream.

### Benefits

It will help more Chinese users who are not proficient in English to understand the functions and usage of Drone faster, reduce the learning cost and attract more Chinese users and developers.

### Screenshot after the change

![image](https://user-images.githubusercontent.com/6902432/236241953-7e97ed12-5bac-4497-8189-2d870fa50f74.png)

![image](https://user-images.githubusercontent.com/6902432/236242321-63b1596a-5dbf-41a0-a651-b6cc5430afa6.png)
