### PR TITLE
docs: [CI-21816]: Removed brew tap drone/drone from docs

### DIFF
--- a/content/cli/install.md
+++ b/content/cli/install.md
@@ -45,8 +45,7 @@ Darwin arm64	| [tarball](https://github.com/harness/drone-cli/releases/latest/do
 * Or download and install on OSX using Homebrew:
 
   ```
-  $ brew tap drone/drone
-  $ brew install drone
+  $ brew install drone-cli
   ```
 
 # Install on Windows


### PR DESCRIPTION
  - Removed brew tap drone/drone
  - Changed brew install drone to brew install drone-cli (the homebrew-core formula)